### PR TITLE
Rename DevFile to Devfile everywhere in the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,19 @@ It selects a devfile from a list of devfiles (from a devfile registry or other s
 
 ```go
 import "github.com/devfile/alizer/pkg/apis/recognizer"
+import "github.com/devfile/alizer/pkg/apis/model"
 
-devfile, err := recognizer.SelectDevFileFromTypes("your/project/path", devfiles)
+// In case you want specific range of schemaVersion for matched devfiles
+devifileFilter := model.DevfileFilter {
+	MinSchemaVersion: "<minimum-schema-version>",
+	MaxSchemaVersion: "<maximum-schema-version>",
+}
+
+// If you don't want a specific range of schemaVersion values
+devfileFilter := model.DevfileFilter{}
+
+// Call match devfiles func
+devfiles, err := recognizer.MatchDevfiles("myproject", devfiles, devifileFilter)
 ```
 
 ## Outputs

--- a/docs/proposals/support_22x_devfiles.md
+++ b/docs/proposals/support_22x_devfiles.md
@@ -199,7 +199,7 @@ type Version struct {
 	Version       string
 }
 
-type DevFileType struct {
+type DevfileType struct {
 	Name        string
 	Language    string
 	ProjectType string

--- a/docs/public/alizer-spec.md
+++ b/docs/public/alizer-spec.md
@@ -7,7 +7,7 @@ This document outlines the features Alizer offers and how they actually work.
 Currently, Alizer provides 3 detection options:
 
 - _Language Detection_ (Language/Tools/Frameworks)
-- _DevFile Detection_
+- _Devfile Detection_
 - _Component Detection_
 
 ## Language Detection
@@ -129,7 +129,7 @@ At this point, it reads its content looking for dependencies to discover framewo
 }
 ```
 
-## DevFile detection
+## Devfile detection
 
 It is possible to select a devfile from a list of devfile metadatas provided by the caller based on information that
 Alizer extracts from the source.

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -49,7 +49,7 @@ type Version struct {
 	Version       string
 }
 
-type DevFileType struct {
+type DevfileType struct {
 	Name        string
 	Language    string
 	ProjectType string
@@ -82,7 +82,7 @@ type PortMatchSubRule struct {
 	SubRegex *regexp.Regexp
 }
 
-type DevFileScore struct {
-	DevFileIndex int
+type DevfileScore struct {
+	DevfileIndex int
 	Score        int
 }

--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -28,134 +28,141 @@ import (
 
 const MinimumAllowedVersion = "2.0.0"
 
-func SelectDevFilesFromTypes(path string, devFileTypes []model.DevFileType) ([]int, error) {
+// DEPRECATION WARNING: This function is deprecated, please use devfile_recognizer.MatchDevfiles
+// instead.
+// func SelectDevFilesFromTypes: Returns a list of devfiles matched for the given application
+func SelectDevFilesFromTypes(path string, devfileTypes []model.DevfileType) ([]int, error) {
 	alizerLogger := utils.GetOrCreateLogger()
 	ctx := context.Background()
 	alizerLogger.V(0).Info("Applying component detection to match a devfile")
-	devFilesIndexes := selectDevFilesFromComponentsDetectedInPath(path, devFileTypes)
-	if len(devFilesIndexes) > 0 {
-		alizerLogger.V(0).Info(fmt.Sprintf("Found %d potential matches", len(devFilesIndexes)))
-		return devFilesIndexes, nil
+	devfilesIndexes := selectDevfilesFromComponentsDetectedInPath(path, devfileTypes)
+	if len(devfilesIndexes) > 0 {
+		alizerLogger.V(0).Info(fmt.Sprintf("Found %d potential matches", len(devfilesIndexes)))
+		return devfilesIndexes, nil
 	}
 	alizerLogger.V(0).Info("No components found, applying language analysis for devfile matching")
 	languages, err := analyze(path, &ctx)
 	if err != nil {
 		return []int{}, err
 	}
-	devfile, err := SelectDevFileUsingLanguagesFromTypes(languages, devFileTypes)
+	devfile, err := SelectDevfileUsingLanguagesFromTypes(languages, devfileTypes)
 	if err != nil {
 		return []int{}, errors.New("No valid devfile found for project in " + path)
 	}
 	return []int{devfile}, nil
 }
 
-func selectDevFilesFromComponentsDetectedInPath(path string, devFileTypes []model.DevFileType) []int {
+func selectDevfilesFromComponentsDetectedInPath(path string, devfileTypes []model.DevfileType) []int {
 	components, _ := DetectComponentsInRoot(path)
-	devFilesIndexes := selectDevFilesFromComponents(components, devFileTypes)
-	if len(devFilesIndexes) > 0 {
-		return devFilesIndexes
+	devfilesIndexes := selectDevfilesFromComponents(components, devfileTypes)
+	if len(devfilesIndexes) > 0 {
+		return devfilesIndexes
 	}
 
 	components, _ = DetectComponents(path)
-	return selectDevFilesFromComponents(components, devFileTypes)
+	return selectDevfilesFromComponents(components, devfileTypes)
 }
 
-func selectDevFilesFromComponents(components []model.Component, devFileTypes []model.DevFileType) []int {
-	var devFilesIndexes []int
+func selectDevfilesFromComponents(components []model.Component, devfileTypes []model.DevfileType) []int {
+	var devfilesIndexes []int
 	for _, component := range components {
-		devFiles, err := selectDevFilesByLanguage(component.Languages[0], devFileTypes)
+		devfiles, err := selectDevfilesByLanguage(component.Languages[0], devfileTypes)
 		if err == nil {
-			devFilesIndexes = append(devFilesIndexes, devFiles...)
+			devfilesIndexes = append(devfilesIndexes, devfiles...)
 		}
 	}
-	return devFilesIndexes
+	return devfilesIndexes
 }
 
-func SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (int, error) {
-	devfiles, err := SelectDevFilesFromTypes(path, devFileTypes)
+// DEPRECATION WARNING: This function is deprecated, please use devfile_recognizer.MatchDevfiles
+// instead.
+// func SelectDevFileFromTypes: Returns the first devfile from the list of devfiles returned
+// from SelectDevFilesFromTypes func. It also returns an error if exists.
+func SelectDevFileFromTypes(path string, devfileTypes []model.DevfileType) (int, error) {
+	devfiles, err := SelectDevFilesFromTypes(path, devfileTypes)
 	if err != nil {
 		return -1, err
 	}
 	return devfiles[0], nil
 }
 
-func SelectDevFilesUsingLanguagesFromTypes(languages []model.Language, devFileTypes []model.DevFileType) ([]int, error) {
-	var devFilesIndexes []int
+func SelectDevfilesUsingLanguagesFromTypes(languages []model.Language, devfileTypes []model.DevfileType) ([]int, error) {
+	var devfilesIndexes []int
 	alizerLogger := utils.GetOrCreateLogger()
 	alizerLogger.V(1).Info("Searching potential matches from detected languages")
 	for _, language := range languages {
 		alizerLogger.V(1).Info(fmt.Sprintf("Accessing %s language", language.Name))
-		devFiles, err := selectDevFilesByLanguage(language, devFileTypes)
+		devfiles, err := selectDevfilesByLanguage(language, devfileTypes)
 		if err == nil {
-			alizerLogger.V(1).Info(fmt.Sprintf("Found %d potential matches for language %s", len(devFiles), language.Name))
-			devFilesIndexes = append(devFilesIndexes, devFiles...)
+			alizerLogger.V(1).Info(fmt.Sprintf("Found %d potential matches for language %s", len(devfiles), language.Name))
+			devfilesIndexes = append(devfilesIndexes, devfiles...)
 		}
 	}
-	if len(devFilesIndexes) > 0 {
-		return devFilesIndexes, nil
+	if len(devfilesIndexes) > 0 {
+		return devfilesIndexes, nil
 	}
 	return []int{}, errors.New("no valid devfile found by using those languages")
 }
 
-func SelectDevFileUsingLanguagesFromTypes(languages []model.Language, devFileTypes []model.DevFileType) (int, error) {
-	devFilesIndexes, err := SelectDevFilesUsingLanguagesFromTypes(languages, devFileTypes)
+func SelectDevfileUsingLanguagesFromTypes(languages []model.Language, devfileTypes []model.DevfileType) (int, error) {
+	devfilesIndexes, err := SelectDevfilesUsingLanguagesFromTypes(languages, devfileTypes)
 	if err != nil {
 		return -1, err
 	}
-	return devFilesIndexes[0], nil
+	return devfilesIndexes[0], nil
 }
 
-func MatchDevfiles(path string, url string, filter model.DevfileFilter) ([]model.DevFileType, error) {
+func MatchDevfiles(path string, url string, filter model.DevfileFilter) ([]model.DevfileType, error) {
 	alizerLogger := utils.GetOrCreateLogger()
 	alizerLogger.V(0).Info("Starting devfile matching")
 	alizerLogger.V(1).Info(fmt.Sprintf("Downloading devfiles from registry %s", url))
-	devFileTypesFromRegistry, err := DownloadDevFileTypesFromRegistry(url, filter)
+	devfileTypesFromRegistry, err := DownloadDevfileTypesFromRegistry(url, filter)
 	if err != nil {
-		return []model.DevFileType{}, err
+		return []model.DevfileType{}, err
 	}
 
-	return selectDevfiles(path, devFileTypesFromRegistry)
+	return selectDevfiles(path, devfileTypesFromRegistry)
 }
 
-func SelectDevFilesFromRegistry(path string, url string) ([]model.DevFileType, error) {
+func SelectDevfilesFromRegistry(path string, url string) ([]model.DevfileType, error) {
 	alizerLogger := utils.GetOrCreateLogger()
 	alizerLogger.V(0).Info("Starting devfile matching")
 	alizerLogger.V(1).Info(fmt.Sprintf("Downloading devfiles from registry %s", url))
-	devFileTypesFromRegistry, err := DownloadDevFileTypesFromRegistry(url, model.DevfileFilter{MinSchemaVersion: "", MaxSchemaVersion: ""})
+	devfileTypesFromRegistry, err := DownloadDevfileTypesFromRegistry(url, model.DevfileFilter{MinSchemaVersion: "", MaxSchemaVersion: ""})
 	if err != nil {
-		return []model.DevFileType{}, err
+		return []model.DevfileType{}, err
 	}
 
-	return selectDevfiles(path, devFileTypesFromRegistry)
+	return selectDevfiles(path, devfileTypesFromRegistry)
 }
 
 // selectDevfiles is exposed as global var in the purpose of mocking tests
-var selectDevfiles = func(path string, devFileTypesFromRegistry []model.DevFileType) ([]model.DevFileType, error) {
-	indexes, err := SelectDevFilesFromTypes(path, devFileTypesFromRegistry)
+var selectDevfiles = func(path string, devfileTypesFromRegistry []model.DevfileType) ([]model.DevfileType, error) {
+	indexes, err := SelectDevFilesFromTypes(path, devfileTypesFromRegistry)
 	if err != nil {
-		return []model.DevFileType{}, err
+		return []model.DevfileType{}, err
 	}
 
-	var devFileTypes []model.DevFileType
+	var devfileTypes []model.DevfileType
 	for _, index := range indexes {
-		devFileTypes = append(devFileTypes, devFileTypesFromRegistry[index])
+		devfileTypes = append(devfileTypes, devfileTypesFromRegistry[index])
 	}
 
-	return devFileTypes, nil
+	return devfileTypes, nil
 
 }
 
-func SelectDevFileFromRegistry(path string, url string) (model.DevFileType, error) {
-	devFileTypes, err := DownloadDevFileTypesFromRegistry(url, model.DevfileFilter{MinSchemaVersion: "", MaxSchemaVersion: ""})
+func SelectDevfileFromRegistry(path string, url string) (model.DevfileType, error) {
+	devfileTypes, err := DownloadDevfileTypesFromRegistry(url, model.DevfileFilter{MinSchemaVersion: "", MaxSchemaVersion: ""})
 	if err != nil {
-		return model.DevFileType{}, err
+		return model.DevfileType{}, err
 	}
 
-	index, err := SelectDevFileFromTypes(path, devFileTypes)
+	index, err := SelectDevFileFromTypes(path, devfileTypes)
 	if err != nil {
-		return model.DevFileType{}, err
+		return model.DevfileType{}, err
 	}
-	return devFileTypes[index], nil
+	return devfileTypes[index], nil
 }
 
 func GetUrlWithVersions(url, minSchemaVersion, maxSchemaVersion string) (string, error) {
@@ -204,8 +211,8 @@ func GetUrlWithVersions(url, minSchemaVersion, maxSchemaVersion string) (string,
 	}
 }
 
-// DownloadDevFileTypesFromRegistry is exposed as a global variable for the purpose of running mock tests
-var DownloadDevFileTypesFromRegistry = func(url string, filter model.DevfileFilter) ([]model.DevFileType, error) {
+// DownloadDevfileTypesFromRegistry is exposed as a global variable for the purpose of running mock tests
+var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilter) ([]model.DevfileType, error) {
 	url = adaptUrl(url)
 	tmpUrl := appendIndexPath(url)
 	url, err := GetUrlWithVersions(tmpUrl, filter.MinSchemaVersion, filter.MaxSchemaVersion)
@@ -215,7 +222,7 @@ var DownloadDevFileTypesFromRegistry = func(url string, filter model.DevfileFilt
 	// This value is set by the user in order to configure the registry
 	resp, err := http.Get(url) // #nosec G107
 	if err != nil {
-		return []model.DevFileType{}, err
+		return []model.DevfileType{}, err
 	}
 	defer func() error {
 		if err := resp.Body.Close(); err != nil {
@@ -226,21 +233,21 @@ var DownloadDevFileTypesFromRegistry = func(url string, filter model.DevfileFilt
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
-		return []model.DevFileType{}, errors.New("unable to fetch devfiles from the registry")
+		return []model.DevfileType{}, errors.New("unable to fetch devfiles from the registry")
 	}
 
 	body, err2 := ioutil.ReadAll(resp.Body)
 	if err2 != nil {
-		return []model.DevFileType{}, errors.New("unable to fetch devfiles from the registry")
+		return []model.DevfileType{}, errors.New("unable to fetch devfiles from the registry")
 	}
 
-	var devFileTypes []model.DevFileType
-	err = json.Unmarshal(body, &devFileTypes)
+	var devfileTypes []model.DevfileType
+	err = json.Unmarshal(body, &devfileTypes)
 	if err != nil {
-		return []model.DevFileType{}, errors.New("unable to fetch devfiles from the registry")
+		return []model.DevfileType{}, errors.New("unable to fetch devfiles from the registry")
 	}
 
-	return devFileTypes, nil
+	return devfileTypes, nil
 }
 
 func appendIndexPath(url string) string {
@@ -263,7 +270,7 @@ func adaptUrl(url string) string {
 	return url
 }
 
-// selectDevFilesByLanguage detects devfiles that fit best with a project.
+// selectDevfilesByLanguage detects devfiles that fit best with a project.
 //
 // Performs a search in two steps looping through all devfiles available.
 // When a framework is detected, this is stored in a map but still not saved. A check is made eventually as there could be that a future or
@@ -272,21 +279,21 @@ func adaptUrl(url string) string {
 //
 // At the end, if some framework is supported by some devfile, they are returned. Otherwise, Alizer was not able to find any
 // specific devfile for the frameworks detected and returned the devfiles which got the largest score.
-func selectDevFilesByLanguage(language model.Language, devFileTypes []model.DevFileType) ([]int, error) {
-	var devFileIndexes []int
-	frameworkPerDevFile := make(map[string]model.DevFileScore)
+func selectDevfilesByLanguage(language model.Language, devfileTypes []model.DevfileType) ([]int, error) {
+	var devfileIndexes []int
+	frameworkPerDevfile := make(map[string]model.DevfileScore)
 	scoreTarget := 0
 
-	for index, devFile := range devFileTypes {
+	for index, devfile := range devfileTypes {
 		score := 0
 		frameworkPerDevfileTmp := make(map[string]interface{})
-		if strings.EqualFold(devFile.Language, language.Name) || matches(language.Aliases, devFile.Language) != "" {
+		if strings.EqualFold(devfile.Language, language.Name) || matches(language.Aliases, devfile.Language) != "" {
 			score++
-			if frw := matchesFormatted(language.Frameworks, devFile.ProjectType); frw != "" {
+			if frw := matchesFormatted(language.Frameworks, devfile.ProjectType); frw != "" {
 				frameworkPerDevfileTmp[frw] = nil
 				score += utils.FRAMEWORK_WEIGHT
 			}
-			for _, tag := range devFile.Tags {
+			for _, tag := range devfile.Tags {
 				if frw := matchesFormatted(language.Frameworks, tag); frw != "" {
 					frameworkPerDevfileTmp[frw] = nil
 					score += utils.FRAMEWORK_WEIGHT
@@ -297,37 +304,37 @@ func selectDevFilesByLanguage(language model.Language, devFileTypes []model.DevF
 			}
 
 			for framework := range frameworkPerDevfileTmp {
-				devFileObj := frameworkPerDevFile[framework]
-				if score > devFileObj.Score {
-					frameworkPerDevFile[framework] = model.DevFileScore{
-						DevFileIndex: index,
+				devfileObj := frameworkPerDevfile[framework]
+				if score > devfileObj.Score {
+					frameworkPerDevfile[framework] = model.DevfileScore{
+						DevfileIndex: index,
 						Score:        score,
 					}
 				}
 			}
 
-			if len(frameworkPerDevFile) == 0 {
+			if len(frameworkPerDevfile) == 0 {
 				if score == scoreTarget {
-					devFileIndexes = append(devFileIndexes, index)
+					devfileIndexes = append(devfileIndexes, index)
 				} else if score > scoreTarget {
 					scoreTarget = score
-					devFileIndexes = []int{index}
+					devfileIndexes = []int{index}
 				}
 			}
 		}
 	}
 
-	if len(frameworkPerDevFile) > 0 {
-		devFileIndexes = []int{}
-		for _, val := range frameworkPerDevFile {
-			devFileIndexes = append(devFileIndexes, val.DevFileIndex)
+	if len(frameworkPerDevfile) > 0 {
+		devfileIndexes = []int{}
+		for _, val := range frameworkPerDevfile {
+			devfileIndexes = append(devfileIndexes, val.DevfileIndex)
 		}
 	}
 
-	if len(devFileIndexes) == 0 {
-		return devFileIndexes, errors.New("No valid devfile found for current language " + language.Name)
+	if len(devfileIndexes) == 0 {
+		return devfileIndexes, errors.New("No valid devfile found for current language " + language.Name)
 	}
-	return devFileIndexes, nil
+	return devfileIndexes, nil
 }
 
 func matchesFormatted(values []string, valueToFind string) string {

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -22,39 +22,39 @@ import (
 )
 
 func TestDetectQuarkusDevfile(t *testing.T) {
-	detectDevFiles(t, "quarkus", []string{"java-quarkus"})
+	detectDevfiles(t, "quarkus", []string{"java-quarkus"})
 }
 
 func TestDetectMicronautDevfile(t *testing.T) {
-	detectDevFiles(t, "micronaut", []string{"java-maven"})
+	detectDevfiles(t, "micronaut", []string{"java-maven"})
 }
 
 func TestDetectNodeJSDevfile(t *testing.T) {
-	detectDevFiles(t, "nodejs-ex", []string{"nodejs"})
+	detectDevfiles(t, "nodejs-ex", []string{"nodejs"})
 }
 
 func TestDetectDotNet50Devfile(t *testing.T) {
-	detectDevFile(t, "dotnet5.0", []string{"dotnet50"})
+	detectDevfile(t, "dotnet5.0", []string{"dotnet50"})
 }
 
 func TestDetectDotNet60Devfile(t *testing.T) {
-	detectDevFile(t, "dotnet6.0", []string{"dotnet60"})
+	detectDevfile(t, "dotnet6.0", []string{"dotnet60"})
 }
 
 func TestDetectDotNetCore31Devfile(t *testing.T) {
-	detectDevFile(t, "dotnetcore3.1", []string{"dotnetcore31"})
+	detectDevfile(t, "dotnetcore3.1", []string{"dotnetcore31"})
 }
 
 func TestDetectDjangoDevfile(t *testing.T) {
-	detectDevFiles(t, "django", []string{"python-django"})
+	detectDevfiles(t, "django", []string{"python-django"})
 }
 
 func TestDetectFlaskDevfile(t *testing.T) {
-	detectDevFiles(t, "flask", []string{"python"})
+	detectDevfiles(t, "flask", []string{"python"})
 }
 
 func TestDetectWildflyDevfile(t *testing.T) {
-	detectDevFiles(t, "wildfly", []string{"java-wildfly"})
+	detectDevfiles(t, "wildfly", []string{"java-wildfly"})
 }
 
 func TestDetectDjangoDevfileUsingLanguages(t *testing.T) {
@@ -82,59 +82,59 @@ func TestDetectDjangoDevfileUsingLanguages(t *testing.T) {
 			CanBeComponent: false,
 		},
 	}
-	detectDevFilesUsingLanguages(t, "", languages, []string{"python-django"})
+	detectDevfilesUsingLanguages(t, "", languages, []string{"python-django"})
 }
 
 func TestDetectQuarkusDevfileUsingLanguages(t *testing.T) {
-	detectDevFilesUsingLanguages(t, "quarkus", []model.Language{}, []string{"java-quarkus"})
+	detectDevfilesUsingLanguages(t, "quarkus", []model.Language{}, []string{"java-quarkus"})
 }
 
 func TestDetectMicronautDevfileUsingLanguages(t *testing.T) {
-	detectDevFilesUsingLanguages(t, "micronaut", []model.Language{}, []string{"java-maven"})
+	detectDevfilesUsingLanguages(t, "micronaut", []model.Language{}, []string{"java-maven"})
 }
 
 func TestDetectNodeJSDevfileUsingLanguages(t *testing.T) {
-	detectDevFilesUsingLanguages(t, "nodejs-ex", []model.Language{}, []string{"nodejs"})
+	detectDevfilesUsingLanguages(t, "nodejs-ex", []model.Language{}, []string{"nodejs"})
 }
 
 func TestDetectGoDevfile(t *testing.T) {
-	detectDevFiles(t, "golang-gin-app", []string{"go"})
+	detectDevfiles(t, "golang-gin-app", []string{"go"})
 }
 
 func TestDetectAngularDevfile(t *testing.T) {
-	detectDevFiles(t, "angularjs", []string{"Angular"})
+	detectDevfiles(t, "angularjs", []string{"Angular"})
 }
 
 func TestDetectVertxDevfile(t *testing.T) {
-	detectDevFile(t, "vertx", []string{"java-vertx"})
+	detectDevfile(t, "vertx", []string{"java-vertx"})
 }
 
 func TestDetectNextJsDevfile(t *testing.T) {
-	detectDevFiles(t, "nextjs-app", []string{"Next.js"})
+	detectDevfiles(t, "nextjs-app", []string{"Next.js"})
 }
 
 func TestDetectNuxtJsDevfile(t *testing.T) {
-	detectDevFiles(t, "nuxtjs-app", []string{"nodejs-nuxtjs", "nodejs-vue"})
+	detectDevfiles(t, "nuxtjs-app", []string{"nodejs-nuxtjs", "nodejs-vue"})
 }
 
 func TestDetectVueDevfile(t *testing.T) {
-	detectDevFiles(t, "vue-app", []string{"nodejs-vue"})
+	detectDevfiles(t, "vue-app", []string{"nodejs-vue"})
 }
 
 func TestDetectReactJSDevfile(t *testing.T) {
-	detectDevFiles(t, "reactjs", []string{"nodejs-react"})
+	detectDevfiles(t, "reactjs", []string{"nodejs-react"})
 }
 
 func TestDetectSvelteDevfile(t *testing.T) {
-	detectDevFiles(t, "svelte-app", []string{"nodejs-svelte"})
+	detectDevfiles(t, "svelte-app", []string{"nodejs-svelte"})
 }
 
 func TestDetectSpringDevfile(t *testing.T) {
-	detectDevFiles(t, "spring", []string{"java-spring", "java-springboot"})
+	detectDevfiles(t, "spring", []string{"java-spring", "java-springboot"})
 }
 
 func TestDetectLaravelDevfile(t *testing.T) {
-	detectDevFiles(t, "laravel", []string{"php-laravel"})
+	detectDevfiles(t, "laravel", []string{"php-laravel"})
 }
 
 func TestGetUrlWithVersions(t *testing.T) {
@@ -224,7 +224,7 @@ func TestMatchDevfiles(t *testing.T) {
 		mockFunc            func()
 		url                 string
 		path                string
-		expectedDevfileType model.DevFileType
+		expectedDevfileType model.DevfileType
 		expectingErr        bool
 	}{
 		{
@@ -232,7 +232,7 @@ func TestMatchDevfiles(t *testing.T) {
 			filter: model.DevfileFilter{},
 			path:   "some-path",
 			url:    "some-url",
-			expectedDevfileType: model.DevFileType{
+			expectedDevfileType: model.DevfileType{
 				Name:        "mocked-stack",
 				Language:    "python",
 				ProjectType: "python",
@@ -245,12 +245,12 @@ func TestMatchDevfiles(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(tt *testing.T) {
-			// mock DownloadDevFileTypesFromRegistry
-			DownloadDevFileTypesFromRegistry = func(url string, filter model.DevfileFilter) ([]model.DevFileType, error) {
-				return []model.DevFileType{tc.expectedDevfileType}, nil
+			// mock DownloadDevfileTypesFromRegistry
+			DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilter) ([]model.DevfileType, error) {
+				return []model.DevfileType{tc.expectedDevfileType}, nil
 			}
-			selectDevfiles = func(path string, devFileTypesFromRegistry []model.DevFileType) ([]model.DevFileType, error) {
-				return []model.DevFileType{tc.expectedDevfileType}, nil
+			selectDevfiles = func(path string, devfileTypesFromRegistry []model.DevfileType) ([]model.DevfileType, error) {
+				return []model.DevfileType{tc.expectedDevfileType}, nil
 			}
 			devfileType, err := MatchDevfiles("test-path", "some-url", model.DevfileFilter{})
 
@@ -280,24 +280,24 @@ func getExceptedVersionsUrl(url, minSchemaVersion, maxSchemaVersion string, err 
 	}
 }
 
-func detectDevFiles(t *testing.T, projectName string, devFilesName []string) {
-	detectDevFilesFunc := func(devFileTypes []model.DevFileType) ([]int, error) {
+func detectDevfiles(t *testing.T, projectName string, devfilesName []string) {
+	detectDevfilesFunc := func(devfileTypes []model.DevfileType) ([]int, error) {
 		testingProjectPath := getTestProjectPath(projectName)
-		return SelectDevFilesFromTypes(testingProjectPath, devFileTypes)
+		return SelectDevFilesFromTypes(testingProjectPath, devfileTypes)
 	}
-	detectDevFilesInner(t, devFilesName, detectDevFilesFunc)
+	detectDevfilesInner(t, devfilesName, detectDevfilesFunc)
 }
 
-func detectDevFile(t *testing.T, projectName string, devFilesName []string) {
-	detectDevFilesFunc := func(devFileTypes []model.DevFileType) ([]int, error) {
+func detectDevfile(t *testing.T, projectName string, devfilesName []string) {
+	detectDevfilesFunc := func(devfileTypes []model.DevfileType) ([]int, error) {
 		testingProjectPath := getTestProjectPath(projectName)
-		devfileIndex, err := SelectDevFileFromTypes(testingProjectPath, devFileTypes)
+		devfileIndex, err := SelectDevFileFromTypes(testingProjectPath, devfileTypes)
 		return []int{devfileIndex}, err
 	}
-	detectDevFilesInner(t, devFilesName, detectDevFilesFunc)
+	detectDevfilesInner(t, devfilesName, detectDevfilesFunc)
 }
 
-func detectDevFilesUsingLanguages(t *testing.T, projectName string, languages []model.Language, devFileName []string) {
+func detectDevfilesUsingLanguages(t *testing.T, projectName string, languages []model.Language, devfileName []string) {
 	if projectName != "" {
 		testingProjectPath := getTestProjectPath(projectName)
 		var err error
@@ -306,36 +306,36 @@ func detectDevFilesUsingLanguages(t *testing.T, projectName string, languages []
 			t.Error(err)
 		}
 	}
-	detectDevFileFunc := func(devFileTypes []model.DevFileType) ([]int, error) {
-		return SelectDevFilesUsingLanguagesFromTypes(languages, devFileTypes)
+	detectDevfileFunc := func(devfileTypes []model.DevfileType) ([]int, error) {
+		return SelectDevfilesUsingLanguagesFromTypes(languages, devfileTypes)
 	}
-	detectDevFilesInner(t, devFileName, detectDevFileFunc)
+	detectDevfilesInner(t, devfileName, detectDevfileFunc)
 }
 
-func detectDevFilesInner(t *testing.T, expectedDevFilesName []string, detectFuncInner func([]model.DevFileType) ([]int, error)) {
-	devFileTypes := getDevFileTypes()
-	foundDevFilesIndexes, err := detectFuncInner(devFileTypes)
+func detectDevfilesInner(t *testing.T, expectedDevfilesName []string, detectFuncInner func([]model.DevfileType) ([]int, error)) {
+	devfileTypes := getDevfileTypes()
+	foundDevfilesIndexes, err := detectFuncInner(devfileTypes)
 	if err != nil {
 		t.Error(err)
 	}
 
 	found := false
-	for _, expectedDevFile := range expectedDevFilesName {
+	for _, expectedDevfile := range expectedDevfilesName {
 		found = false
-		for _, foundDevFileIndex := range foundDevFilesIndexes {
-			if devFileTypes[foundDevFileIndex].Name == expectedDevFile {
+		for _, foundDevfileIndex := range foundDevfilesIndexes {
+			if devfileTypes[foundDevfileIndex].Name == expectedDevfile {
 				found = true
 			}
 		}
 		if !found {
-			t.Error("Expected value " + expectedDevFile + " but it was not found")
+			t.Error("Expected value " + expectedDevfile + " but it was not found")
 			return
 		}
 	}
 }
 
-func getDevFileTypes() []model.DevFileType {
-	return []model.DevFileType{
+func getDevfileTypes() []model.DevfileType {
+	return []model.DevfileType{
 		{
 			Name:        "java",
 			Language:    "java",

--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -166,7 +166,7 @@ func main() {
 	projectReplacements := getProjectReplacements()
 
 	for _, registry := range devfileRegistries {
-		tmpDevfileTypes, err := recognizer.DownloadDevFileTypesFromRegistry(registry.Url, registry.Filter)
+		tmpDevfileTypes, err := recognizer.DownloadDevfileTypesFromRegistry(registry.Url, registry.Filter)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## What does this PR do?

This PR ensures that every variable having the name devfile does not contain a capital F for the devfile word. The only two exceptions are the `func SelectDevFileFromTypes` and `func SelectDevfilesFromTypes` which remain the same. A deprecation warning has been added in the code. Soon they will have to be removed in favor of `recognizer.MatchDevfiles` which additionally includes `devfileFilters` in order to filter the fetched stacks from the registry.

Along with code updates, changes were made in the tests and in the documentation.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1173

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
