### PR TITLE
Add --no-port-detection flag to compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ $ go build alizer.go
 
 ```sh
   --log {debug|info|warning}    sets the logging level of the CLI. The arg accepts only 3 values [`debug`, `info`, `warning`]. The default value is `warning` and the logging level is `ErrorLevel`.
+  --no-port-detection if this flag exists then no port detection is applied on the given application. If this flag doesn't exist then we are applying port detection as normal. In case we have both --no-port-detection and --port-detection the --no-port-detection overrides everything.
   --port-detection {docker|compose|source}    port detection strategy to use when detecting a port. Currently supported strategies are 'docker', 'compose' and 'source'. You can pass more strategies at the same time. They will be executed in order. By default Alizer will execute docker, compose and source.
 ```
+**Deprecation Warning:** The `--port-detection` flag soon will be deprecated.
 
 #### alizer devfile
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ It detects all components which are found in the source tree where each componen
 ```go
 import "github.com/devfile/alizer/pkg/apis/recognizer"
 
+// In case port detection is needed.
 components, err := recognizer.DetectComponents("your/project/path")
+
+// If there is no need for port detection
+components, err := recognizer.DetectComponentsWithoutPortDetection("your/project/path")
 ```
 
 For more info about name detection, see the [name detection](docs/public/name_detection.md) doc.

--- a/docs/public/port_detection.md
+++ b/docs/public/port_detection.md
@@ -2,6 +2,8 @@
 
 Port detection is one of the step included during component detection and it refers to the ports used by the component that should be opened in the container. Because of the different nature of frameworks supported, Alizer tries to use customized ways to detect ports from source code, if necessary. **Only ports with value > 0 and < 65535 are valid**
 
+**Deprecation Warning:** The port detection strategies will be removed in the future releases of alizer.
+
 There are three detection strategies currently available:
 1) Docker file - Alizer looks for a Dockerfile, or Containerfile, in the root folder and tries to extract ports from it.
 2) Compose file - Alizer searches for a docker-compose file in the root folder and tries to extract port of the service from it

--- a/pkg/apis/recognizer/component_recognizer.go
+++ b/pkg/apis/recognizer/component_recognizer.go
@@ -60,7 +60,8 @@ func DetectComponentsWithPathAndPortStartegy(path string, portDetectionStrategy 
 	return detectComponentsWithPathAndPortStartegy(path, portDetectionStrategy, &ctx)
 }
 
-func detectComponentsWithPathAndPortStartegy(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
+// detectComponentsWithPathAndPortStartegy is exposed as a global variable for the purpose of running mock tests
+var detectComponentsWithPathAndPortStartegy = func(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
 	return detectComponentsWithSettings(model.DetectionSettings{
 		BasePath:              path,
 		PortDetectionStrategy: portDetectionStrategy,

--- a/pkg/apis/recognizer/component_recognizer.go
+++ b/pkg/apis/recognizer/component_recognizer.go
@@ -60,8 +60,7 @@ func DetectComponentsWithPathAndPortStartegy(path string, portDetectionStrategy 
 	return detectComponentsWithPathAndPortStartegy(path, portDetectionStrategy, &ctx)
 }
 
-// detectComponentsWithPathAndPortStartegy is exposed as a global variable for the purpose of running mock tests
-var detectComponentsWithPathAndPortStartegy = func(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
+func detectComponentsWithPathAndPortStartegy(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
 	return detectComponentsWithSettings(model.DetectionSettings{
 		BasePath:              path,
 		PortDetectionStrategy: portDetectionStrategy,

--- a/pkg/apis/recognizer/component_recognizer.go
+++ b/pkg/apis/recognizer/component_recognizer.go
@@ -38,6 +38,11 @@ func DetectComponents(path string) ([]model.Component, error) {
 	return detectComponentsWithPathAndPortStartegy(path, []model.PortDetectionAlgorithm{model.DockerFile, model.Compose, model.Source}, &ctx)
 }
 
+func DetectComponentsWithoutPortDetection(path string) ([]model.Component, error) {
+	ctx := context.Background()
+	return detectComponentsWithPathAndPortStartegy(path, []model.PortDetectionAlgorithm{}, &ctx)
+}
+
 func DetectComponentsInRootWithPathAndPortStartegy(path string, portDetectionStrategy []model.PortDetectionAlgorithm) ([]model.Component, error) {
 	ctx := context.Background()
 	return detectComponentsInRootWithPathAndPortStartegy(path, portDetectionStrategy, &ctx)

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -310,6 +310,113 @@ func TestDetectComponentsInRootWithSettings(t *testing.T) {
 	}
 }
 
+func Test_detectComponentsWithPathAndPortStartegy(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			ctx := context.Background()
+			result, err := detectComponentsWithPathAndPortStartegy(detectionSettings.BasePath, []model.PortDetectionAlgorithm{model.DockerFile, model.Compose, model.Source}, &ctx)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
+func TestDetectComponentsWithPathAndPortStartegy(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			result, err := DetectComponentsWithPathAndPortStartegy(detectionSettings.BasePath, []model.PortDetectionAlgorithm{model.DockerFile, model.Compose, model.Source})
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
 func getDetectionSettings(path string) (model.DetectionSettings, error) {
 	absPath, err := getAbsolutePath(path)
 	if err != nil {

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -2,7 +2,10 @@ package recognizer
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/devfile/alizer/pkg/apis/model"
@@ -100,4 +103,77 @@ func Test_isAnyComponentInDirectPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_detectComponentsWithSettings(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			ctx := context.Background()
+			result, err := detectComponentsWithSettings(detectionSettings, &ctx)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
+func getDetectionSettings(path string) (model.DetectionSettings, error) {
+	absPath, err := getAbsolutePath(path)
+	if err != nil {
+		return model.DetectionSettings{}, err
+	}
+	return model.DetectionSettings{
+		BasePath:              absPath,
+		PortDetectionStrategy: []model.PortDetectionAlgorithm{model.Compose, model.DockerFile, model.Source},
+	}, nil
+}
+
+func getAbsolutePath(path string) (string, error) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{filepath.Clean(filepath.Join(pwd, path)), "/"}, ""), nil
 }

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -159,6 +159,166 @@ func Test_detectComponentsWithSettings(t *testing.T) {
 	}
 }
 
+func TestDetectComponentsWithSettings(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			result, err := DetectComponentsWithSettings(detectionSettings)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
+func Test_detectComponentsInRootWithSettings(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			ctx := context.Background()
+			result, err := detectComponentsInRootWithSettings(detectionSettings, &ctx)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
+func TestDetectComponentsInRootWithSettings(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detectionSettings, err := getDetectionSettings(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			result, err := DetectComponentsInRootWithSettings(detectionSettings)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
 func getDetectionSettings(path string) (model.DetectionSettings, error) {
 	absPath, err := getAbsolutePath(path)
 	if err != nil {

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -1,10 +1,54 @@
 package recognizer
 
 import (
-	"github.com/devfile/alizer/pkg/apis/model"
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/devfile/alizer/pkg/apis/model"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestDetectComponentsWithoutPortDetection(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		components []model.Component
+		want       bool
+	}{
+		{
+			name: "Case 1: Func successful",
+			path: "/testPath",
+			components: []model.Component{{
+				Name: "test_name",
+				Path: "test/path",
+				Languages: []model.Language{{
+					Name:                    "lang",
+					Aliases:                 []string{"alias"},
+					Weight:                  0.59,
+					Frameworks:              []string{"framework"},
+					Tools:                   []string{"tool"},
+					CanBeComponent:          true,
+					CanBeContainerComponent: true,
+				}},
+				Ports: []int{12345},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// mock detectComponentsWithPathAndPortStartegy
+			detectComponentsWithPathAndPortStartegy = func(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
+				return tt.components, nil
+			}
+			result, err := DetectComponentsWithoutPortDetection("somePath")
+			if err != nil {
+				t.Errorf("Error: %t", err)
+			}
+			assert.EqualValues(t, tt.components, tt.components, result)
+		})
+	}
+}
 
 func Test_isAnyComponentInDirectPath(t *testing.T) {
 	tests := []struct {

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -257,6 +257,112 @@ func Test_detectComponentsInRootWithSettings(t *testing.T) {
 	}
 }
 
+func TestDetectComponentsInRoot(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			absPath, err := getAbsolutePath(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			result, err := DetectComponentsInRoot(absPath)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
+func TestDetectComponents(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		expectedComponents []model.Component
+		expectingError     bool
+	}{
+		{
+			name: "Case 1: detect components",
+			path: "../../../resources/projects/beego",
+			expectedComponents: []model.Component{
+				{
+					Name: "beego",
+					Path: "../../../resources/projects/beego",
+				},
+			},
+			expectingError: false,
+		},
+		{
+			name:               "Case 2: invalid path",
+			path:               "../../../resources/projects/notexisting",
+			expectedComponents: []model.Component{},
+			expectingError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			absPath, err := getAbsolutePath(tt.path)
+			if err != nil {
+				t.Errorf("test failed: Couldn't locate current working directory")
+			}
+			result, err := DetectComponents(absPath)
+			if tt.expectingError {
+				if err == nil {
+					t.Errorf("test Failed: Was expecting path not found")
+				}
+				assert.EqualValues(t, 0, len(result))
+			} else {
+				if len(result) != 1 {
+					t.Errorf("expected 1 component for %s dir", tt.path)
+				}
+				expectedPath, err := getAbsolutePath(tt.expectedComponents[0].Path)
+				if err != nil {
+					t.Errorf("test failed: %s", err)
+				}
+				assert.EqualValues(t, tt.expectedComponents[0].Name, result[0].Name)
+				assert.EqualValues(t, expectedPath, result[0].Path)
+			}
+		})
+	}
+}
+
 func TestDetectComponentsInRootWithSettings(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/pkg/apis/recognizer/component_recognizer_test.go
+++ b/pkg/apis/recognizer/component_recognizer_test.go
@@ -21,34 +21,25 @@ func TestDetectComponentsWithoutPortDetection(t *testing.T) {
 	}{
 		{
 			name: "Case 1: Func successful",
-			path: "/testPath",
+			path: "../../../resources/projects/beego",
 			components: []model.Component{{
-				Name: "test_name",
-				Path: "test/path",
-				Languages: []model.Language{{
-					Name:                    "lang",
-					Aliases:                 []string{"alias"},
-					Weight:                  0.59,
-					Frameworks:              []string{"framework"},
-					Tools:                   []string{"tool"},
-					CanBeComponent:          true,
-					CanBeContainerComponent: true,
-				}},
-				Ports: []int{12345},
+				Name: "beego",
+				Path: "../../../resources/projects/beego",
 			}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// mock detectComponentsWithPathAndPortStartegy
-			detectComponentsWithPathAndPortStartegy = func(path string, portDetectionStrategy []model.PortDetectionAlgorithm, ctx *context.Context) ([]model.Component, error) {
-				return tt.components, nil
-			}
-			result, err := DetectComponentsWithoutPortDetection("somePath")
+			absPath, err := getAbsolutePath(tt.path)
 			if err != nil {
 				t.Errorf("Error: %t", err)
 			}
-			assert.EqualValues(t, tt.components, tt.components, result)
+			result, err := DetectComponentsWithoutPortDetection(absPath)
+			if err != nil {
+				t.Errorf("Error: %t", err)
+			}
+			assert.EqualValues(t, tt.components[0].Name, result[0].Name)
+			assert.EqualValues(t, absPath, result[0].Path)
 		})
 	}
 }

--- a/pkg/cli/component/component.go
+++ b/pkg/cli/component/component.go
@@ -10,6 +10,7 @@ import (
 var (
 	logLevel                string
 	portDetectionAlgorithms []string
+	noPortDetection         bool
 )
 
 func NewCmdComponent() *cobra.Command {
@@ -23,7 +24,8 @@ Examples of components: API Backend, Web Frontend, Payment Backend`,
 		Example: `  alizer component /your/local/project/path`,
 	}
 	componentCmd.Flags().StringVar(&logLevel, "log", "", "log level for alizer. Default value: error. Accepted values: [debug, info, warning]")
-	componentCmd.Flags().StringSliceVarP(&portDetectionAlgorithms, "port-detection", "p", []string{}, "port detection strategy to use when detecting a port. Currently supported strategies are 'docker', 'compose' and 'source'. You can pass more strategies at the same time. They will be executed in order. By default Alizer will execute docker, compose and source.")
+	componentCmd.Flags().StringSliceVarP(&portDetectionAlgorithms, "port-detection", "p", []string{}, "[DEPRECATED] port detection strategy to use when detecting a port. Currently supported strategies are 'docker', 'compose' and 'source'. You can pass more strategies at the same time. They will be executed in order. By default Alizer will execute docker, compose and source.")
+	componentCmd.Flags().BoolVarP(&noPortDetection, "no-port-detection", "n", false, "Skips the execution of port detection for all detected components. As a result no ports will be returned in the response. If it doesn't exist, alizer will run the port detection for all detected components")
 	return componentCmd
 }
 
@@ -42,6 +44,12 @@ func doDetection(cmd *cobra.Command, args []string) {
 
 func getPortDetectionStrategy() []model.PortDetectionAlgorithm {
 	portDetectionStrategy := []model.PortDetectionAlgorithm{}
+
+	// Return empty strategy if no port detection is defined
+	if noPortDetection {
+		return portDetectionStrategy
+	}
+
 	for _, algo := range portDetectionAlgorithms {
 		if algo == "docker" {
 			portDetectionStrategy = append(portDetectionStrategy, model.DockerFile)

--- a/pkg/cli/component/component_test.go
+++ b/pkg/cli/component/component_test.go
@@ -1,0 +1,36 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/devfile/alizer/pkg/apis/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPortStrategy(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		expectedResult       []model.PortDetectionAlgorithm
+		noPortDetectionValue bool
+	}{
+		{
+			name:                 "Case 1: default port detection",
+			expectedResult:       []model.PortDetectionAlgorithm{model.DockerFile, model.Compose, model.Source},
+			noPortDetectionValue: false,
+		},
+		{
+			name:                 "Case 2: no port detection active",
+			expectedResult:       []model.PortDetectionAlgorithm{},
+			noPortDetectionValue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			noPortDetection = tt.noPortDetectionValue
+			result := getPortDetectionStrategy()
+			assert.EqualValues(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR is part of the https://github.com/devfile/api/issues/1153 EPIC and introduces a new optimization to the port detection logic. The new flag we are creating on the `component` command is called `no-port-detection`/`n` and simply skips the port detection part of the command.

In order to do that upon `getPortDetectionStrategy` func of package `component` it checks if the global var `noPortDetection` is true. If yes it applies an early return with an empty `model.PortDetectionAlgorithm` list.

Test cases have been added inside  the new `component_test.go` file also updates have been made to the documentation.

As mentioned inside the proposal of the 1153 EPIC, we also add deprecation warning for the usage of port detection strategies.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1150

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer

I've calculated the time of execution for the new feature by running alizer against https://github.com/openshift/hypershift

With port detection:
```bash
$ time ./alizer component ~/github/alizer-tests/hypershift/
...
0m2,470s
```

Without port detection:
```bash
$ time ./alizer component --no-port-detection ~/github/alizer-tests/hypershift/
...
0m0,154s
```