### PR TITLE
Add alizer binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ nb-configuration.xml
 
 # Local environment
 .env
+
+# Binaries
+alizer


### PR DESCRIPTION
## What does this PR do?

Simply adds the `alizer` filename inside `gitignore` file. This way we can ignore the `alizer` binary in case is built

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->
