### PR TITLE
Detect devfiles only for main language in case of no component found

### DIFF
--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -45,11 +45,29 @@ func SelectDevFilesFromTypes(path string, devfileTypes []model.DevfileType) ([]i
 	if err != nil {
 		return []int{}, err
 	}
-	devfile, err := SelectDevfileUsingLanguagesFromTypes(languages, devfileTypes)
+	mainLanguage, err := getMainLanguage(languages)
+	if err != nil {
+		return []int{}, err
+	}
+	devfiles, err := selectDevfilesByLanguage(mainLanguage, devfileTypes)
 	if err != nil {
 		return []int{}, errors.New("No valid devfile found for project in " + path)
 	}
-	return []int{devfile}, nil
+	return devfiles, nil
+}
+
+func getMainLanguage(languages []model.Language) (model.Language, error) {
+	if len(languages) == 0 {
+		return model.Language{}, fmt.Errorf("cannot detect main language due to empty languages list")
+	}
+
+	mainLanguage := languages[0]
+	for _, language := range languages {
+		if language.Weight > mainLanguage.Weight {
+			mainLanguage = language
+		}
+	}
+	return mainLanguage, nil
 }
 
 func selectDevfilesFromComponentsDetectedInPath(path string, devfileTypes []model.DevfileType) []int {

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -266,7 +266,69 @@ func TestMatchDevfiles(t *testing.T) {
 	}
 }
 
-func TestGetMainLanguage(t *testing.T) {
+func Test_selectDevfilesByLanguage(t *testing.T) {
+	language := model.Language{
+		Name:       "LanguageOne",
+		Frameworks: []string{"Framework"},
+	}
+	otherLanguage := model.Language{
+		Name:       "otherLanguage",
+		Frameworks: []string{"otherFramework"},
+	}
+	devfileTypeOne := model.DevfileType{
+		Name:        language.Frameworks[0],
+		Language:    language.Name,
+		ProjectType: language.Frameworks[0],
+		Tags:        []string{},
+	}
+	devfileTypeTwo := model.DevfileType{
+		Name:        "LanguageTwo",
+		Language:    language.Name,
+		ProjectType: language.Name,
+		Tags:        []string{},
+	}
+	tests := []struct {
+		name            string
+		language        model.Language
+		devfileTypes    []model.DevfileType
+		expectedIndexes []int
+		expectingErr    bool
+	}{
+		{
+			name:            "Case1: Simple match by language",
+			language:        language,
+			devfileTypes:    []model.DevfileType{devfileTypeOne},
+			expectedIndexes: []int{0},
+			expectingErr:    false,
+		}, {
+			name:            "Case2: Match by framework",
+			language:        language,
+			devfileTypes:    []model.DevfileType{devfileTypeTwo, devfileTypeOne},
+			expectedIndexes: []int{1},
+			expectingErr:    false,
+		}, {
+			name:            "Case3: No Match",
+			language:        otherLanguage,
+			devfileTypes:    []model.DevfileType{devfileTypeTwo, devfileTypeOne},
+			expectedIndexes: []int{},
+			expectingErr:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			result, err := selectDevfilesByLanguage(tc.language, tc.devfileTypes)
+			if tc.expectingErr {
+				if err == nil {
+					tt.Errorf("No error raised for case %s", tc.name)
+				}
+			} else {
+				assert.EqualValues(t, tc.expectedIndexes, result)
+			}
+		})
+	}
+}
+
+func Test_getMainLanguage(t *testing.T) {
 	languageOne := model.Language{
 		Name:   "LanguageOne",
 		Weight: 0.60,

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -266,6 +266,116 @@ func TestMatchDevfiles(t *testing.T) {
 	}
 }
 
+func TestSelectDevFilesFromTypes(t *testing.T) {
+	tests := []struct {
+		name                    string
+		path                    string
+		expectedDevfileTypeName string
+		expectingErr            bool
+	}{
+		{
+			name:                    "Case 1: Match devfile success",
+			path:                    "../../../resources/projects/beego",
+			expectedDevfileTypeName: "go",
+			expectingErr:            false,
+		}, {
+			name:                    "Case 2: No Match",
+			path:                    "../../../resources/projects/notexisting",
+			expectedDevfileTypeName: "",
+			expectingErr:            true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			devfileTypes := getDevfileTypes()
+			devfileTypeIndexes, err := SelectDevFilesFromTypes(tc.path, devfileTypes)
+			errExist := err != nil
+			if tc.expectingErr {
+				assert.EqualValues(t, tc.expectingErr, errExist)
+			} else {
+				index := devfileTypeIndexes[0]
+				assert.EqualValues(t, tc.expectedDevfileTypeName, devfileTypes[index].Name)
+			}
+		})
+	}
+}
+
+func Test_selectDevfilesFromComponents(t *testing.T) {
+	tests := []struct {
+		name                    string
+		path                    string
+		components              []model.Component
+		expectedDevfileTypeName string
+	}{
+		{
+			name: "Case 1: Match devfile success",
+			path: "../../../resources/projects/beego",
+			components: []model.Component{
+				{
+					Name: "go",
+					Languages: []model.Language{
+						{
+							Name: "Go",
+						},
+					},
+				},
+			},
+			expectedDevfileTypeName: "go",
+		}, {
+			name:                    "Case 2: No Match",
+			path:                    "../../../resources/projects/notexisting",
+			components:              []model.Component{},
+			expectedDevfileTypeName: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			devfileTypes := getDevfileTypes()
+			devfileTypeIndexes := selectDevfilesFromComponents(tc.components, devfileTypes)
+			if tc.expectedDevfileTypeName == "" {
+				assert.EqualValues(t, 0, len(devfileTypeIndexes))
+			} else {
+				index := devfileTypeIndexes[0]
+				assert.EqualValues(t, tc.expectedDevfileTypeName, devfileTypes[index].Name)
+			}
+		})
+	}
+}
+
+func Test_selectDevfilesFromComponentsDetectedInPath(t *testing.T) {
+	tests := []struct {
+		name                    string
+		path                    string
+		expectedDevfileTypeName string
+		expectingErr            bool
+	}{
+		{
+			name:                    "Case 1: Match devfile success",
+			path:                    "../../../resources/projects/beego",
+			expectedDevfileTypeName: "go",
+		}, {
+			name:                    "Case 2: No Match",
+			path:                    "../../../resources/projects/notexisting",
+			expectedDevfileTypeName: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			devfileTypes := getDevfileTypes()
+			devfileTypeIndexes := selectDevfilesFromComponentsDetectedInPath(tc.path, devfileTypes)
+			if tc.expectedDevfileTypeName == "" {
+				assert.EqualValues(t, 0, len(devfileTypeIndexes))
+			} else {
+				index := devfileTypeIndexes[0]
+				assert.EqualValues(t, tc.expectedDevfileTypeName, devfileTypes[index].Name)
+			}
+		})
+	}
+}
+
 func Test_selectDevfilesByLanguage(t *testing.T) {
 	language := model.Language{
 		Name:       "LanguageOne",

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -266,6 +266,52 @@ func TestMatchDevfiles(t *testing.T) {
 	}
 }
 
+func TestGetMainLanguage(t *testing.T) {
+	languageOne := model.Language{
+		Name:   "LanguageOne",
+		Weight: 0.60,
+	}
+	languageTwo := model.Language{
+		Name:   "LanguageTwo",
+		Weight: 0.40,
+	}
+	tests := []struct {
+		name             string
+		languages        []model.Language
+		expectedLanguage model.Language
+		expectingErr     bool
+	}{
+		{
+			name:             "Case1: First greater weight than second",
+			languages:        []model.Language{languageOne, languageTwo},
+			expectedLanguage: languageOne,
+			expectingErr:     false,
+		}, {
+			name:             "Case2: First smaller weight than second",
+			languages:        []model.Language{languageTwo, languageOne},
+			expectedLanguage: languageOne,
+			expectingErr:     false,
+		}, {
+			name:             "Case3: EmptyList",
+			languages:        []model.Language{},
+			expectedLanguage: languageOne,
+			expectingErr:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			mainLanguage, err := getMainLanguage(tc.languages)
+			if tc.expectingErr {
+				if err == nil {
+					tt.Errorf("No error raised for case %s", tc.name)
+				}
+			} else {
+				assert.EqualValues(t, tc.expectedLanguage, mainLanguage)
+			}
+		})
+	}
+}
+
 func getExceptedVersionsUrl(url, minSchemaVersion, maxSchemaVersion string, err error) string {
 	if err != nil {
 		return ""


### PR DESCRIPTION
## What does this PR do?

This PR updates the logic of `SelectDevfilesFromTypes` in order to match devfiles only for the main language of a source code if no component was found.

More detailed, upon `SelectDevfilesFromTypes`, if no component is found from the component analysis, it tries to match a devfile with the main language of the source code.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1219

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
