### PR TITLE
[Devtools week] Fix nightly run check after wildfly stack update

### DIFF
--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -52,9 +52,9 @@ func getProjectReplacements() []ProjectReplacement {
 		},
 		{
 			Devfile:         "java-wildfly-bootable-jar",
-			ReplacementRepo: "https://github.com/wildfly-extras/wildfly-devfile-examples.git",
-			SubDir:          "",
-			Revision:        "qs",
+			ReplacementRepo: "https://github.com/wildfly-extras/wildfly-jar-maven-plugin.git",
+			SubDir:          "examples/authentication",
+			Revision:        "",
 		},
 		{
 			Devfile:         "java-quarkus",


### PR DESCRIPTION
## What does this PR do?

This PR simply replaces a repo used by the nightly run. More detailed when the job checks for `wildfly-bootable-jar` stack we use the [examples/authentication](https://github.com/wildfly-extras/wildfly-jar-maven-plugin/tree/master/examples/authentication) source code instead of the [wildfly-devfile-examples](https://github.com/wildfly-extras/wildfly-devfile-examples.git). This way we won't use the same repo for both `wildfly` and `wildfly-bootable-jar` stacks as `starterProject` to match the given devfiles.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1248

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
