### PR TITLE
Specify files for port detection for every detector

### DIFF
--- a/docs/public/port_detection.md
+++ b/docs/public/port_detection.md
@@ -74,6 +74,8 @@ services:
 ### Port detection with frameworks
 ### Java Frameworks
 
+For java frameworks not having a secific application file, alizer will only try to detect ports defined inside `.java` files and not inside the entire component directory.
+
 #### Micronaut
 
 Alizer checks if the environment variable MICRONAUT_SERVER_SSL_ENABLED is set to true. If so, both MICRONAUT_SERVER_SSL_PORT and MICRONAUT_SERVER_PORT are checked (if false, only the MICRONAUT_SERVER_PORT is used for verification). Alizer will first look for if the env vars are set in the system and if it doesn't find them it will also look for a dockerfile. If they are not set or they do not contain valid port values, Alizer searches for the `application.[yml|yaml]` file in `src/main/resources` folder and verify if one or more ports are set.
@@ -178,6 +180,8 @@ Alizer searches inside the `pom.xml` file to find any configuration inside the p
 ```
 
 ### Javascript Frameworks
+
+For javascript frameworks not having a secific application file, alizer will only try to detect ports defined inside `.js` files and not inside the entire component directory.
 
 ### Angular
 
@@ -316,6 +320,8 @@ Example
 ```
 
 ### GoLang Frameworks
+
+For golang frameworks not having a secific application file, alizer will only try to detect ports defined inside `.go` files and not inside the entire component directory.
 
 #### Beego
 

--- a/docs/public/port_detection.md
+++ b/docs/public/port_detection.md
@@ -74,7 +74,7 @@ services:
 ### Port detection with frameworks
 ### Java Frameworks
 
-For java frameworks not having a secific application file, alizer will only try to detect ports defined inside `.java` files and not inside the entire component directory.
+For Java frameworks not having a specific application file, Alizer will only try to detect ports defined inside `.java` files and not inside the entire component directory.
 
 #### Micronaut
 

--- a/docs/public/port_detection.md
+++ b/docs/public/port_detection.md
@@ -181,7 +181,7 @@ Alizer searches inside the `pom.xml` file to find any configuration inside the p
 
 ### Javascript Frameworks
 
-For javascript frameworks not having a secific application file, alizer will only try to detect ports defined inside `.js` files and not inside the entire component directory.
+For JavaScript frameworks not having a specific application file, Alizer will only try to detect ports defined inside `.js` files and not inside the entire component directory.
 
 ### Angular
 

--- a/docs/public/port_detection.md
+++ b/docs/public/port_detection.md
@@ -321,7 +321,7 @@ Example
 
 ### GoLang Frameworks
 
-For golang frameworks not having a secific application file, alizer will only try to detect ports defined inside `.go` files and not inside the entire component directory.
+For Golang frameworks not having a specific application file, Alizer will only try to detect ports defined inside `.go` files and not inside the entire component directory.
 
 #### Beego
 

--- a/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -31,6 +31,11 @@ func (d DotNetDetector) GetSupportedFrameworks() []string {
 	return []string{""}
 }
 
+func (d DotNetDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	// not implemented yet
+	return []model.ApplicationFileInfo{}
+}
+
 // DoFrameworkDetection uses configFilePath to check for the name of the framework
 func (d DotNetDetector) DoFrameworkDetection(language *model.Language, configFilePath string) {
 	framework := getFrameworks(configFilePath)
@@ -52,6 +57,7 @@ func (d DotNetDetector) DoFrameworkDetection(language *model.Language, configFil
 }
 
 func (d DotNetDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	// not implemented yet
 }
 
 func getFrameworks(configFilePath string) string {

--- a/pkg/apis/enricher/framework/java/java_detector.go
+++ b/pkg/apis/enricher/framework/java/java_detector.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/devfile/alizer/pkg/schema"
 	"github.com/devfile/alizer/pkg/utils"
 )
 
@@ -36,13 +37,8 @@ func hasFramework(configFile, groupId, artifactId string) (bool, error) {
 
 // GetPortsForJBossFrameworks tries to detect any port information inside javaOpts of configuration
 // of a given profiles plugin
-func GetPortsForJBossFrameworks(pomFilePath, pluginArtifactId, pluginGroupId string) string {
+func GetPortsForJBossFrameworks(pom schema.Pom, pluginArtifactId string, pluginGroupId string) string {
 	portPlaceholder := ""
-	pom, err := utils.GetPomFileContent(pomFilePath)
-	if err != nil {
-		return portPlaceholder
-	}
-
 	re := regexp.MustCompile(`jboss.https?.port=\d*`)
 	// Check for port configuration inside profiles
 	for _, profile := range pom.Profiles.Profile {

--- a/pkg/apis/enricher/framework/java/jboss_eap_detector.go
+++ b/pkg/apis/enricher/framework/java/jboss_eap_detector.go
@@ -44,6 +44,7 @@ func (o JBossEAPDetector) DoFrameworkDetection(language *model.Language, config 
 
 func (o JBossEAPDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	ports := []int{}
+	// Fetch the content of xml for this component
 	appFileInfos := o.GetApplicationFileInfos(component.Path, ctx)
 	if len(appFileInfos) == 0 {
 		return

--- a/pkg/apis/enricher/framework/java/micronaut_detector.go
+++ b/pkg/apis/enricher/framework/java/micronaut_detector.go
@@ -71,14 +71,18 @@ func (m MicronautDetector) DoPortsDetection(component *model.Component, ctx *con
 	if len(appFileInfos) == 0 {
 		return
 	}
-	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
-	if err != nil {
-		return
-	}
 
-	ports = getMicronautPortsFromBytes(fileBytes)
-	if len(ports) > 0 {
-		component.Ports = ports
+	for _, appFileInfo := range appFileInfos {
+		fileBytes, err := utils.GetApplicationFileBytes(appFileInfo)
+		if err != nil {
+			continue
+		}
+
+		ports = getMicronautPortsFromBytes(fileBytes)
+		if len(ports) > 0 {
+			component.Ports = ports
+			return
+		}
 	}
 }
 

--- a/pkg/apis/enricher/framework/java/openliberty_detector.go
+++ b/pkg/apis/enricher/framework/java/openliberty_detector.go
@@ -51,7 +51,7 @@ func (o OpenLibertyDetector) DoFrameworkDetection(language *model.Language, conf
 
 // DoPortsDetection searches for the port in src/main/liberty/config/server.xml and /server.xml
 func (o OpenLibertyDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
-	appFileInfos := m.GetApplicationFileInfos(component.Path, ctx)
+	appFileInfos := o.GetApplicationFileInfos(component.Path, ctx)
 	if len(appFileInfos) == 0 {
 		return
 	}

--- a/pkg/apis/enricher/framework/java/openliberty_detector.go
+++ b/pkg/apis/enricher/framework/java/openliberty_detector.go
@@ -61,7 +61,7 @@ func (o OpenLibertyDetector) DoPortsDetection(component *model.Component, ctx *c
 		return
 	}
 
-	var data model.ServerXml
+	var data model.OpenLibertyServerXml
 	err = xml.Unmarshal(fileBytes, &data)
 	if err != nil {
 		return

--- a/pkg/apis/enricher/framework/java/openliberty_detector.go
+++ b/pkg/apis/enricher/framework/java/openliberty_detector.go
@@ -56,18 +56,21 @@ func (o OpenLibertyDetector) DoPortsDetection(component *model.Component, ctx *c
 		return
 	}
 
-	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
-	if err != nil {
-		return
-	}
+	for _, appFileInfo := range appFileInfos {
+		fileBytes, err := utils.GetApplicationFileBytes(appFileInfo)
+		if err != nil {
+			continue
+		}
 
-	var data model.OpenLibertyServerXml
-	err = xml.Unmarshal(fileBytes, &data)
-	if err != nil {
-		return
-	}
-	ports := utils.GetValidPorts([]string{data.HttpEndpoint.HttpPort, data.HttpEndpoint.HttpsPort})
-	if len(ports) > 0 {
-		component.Ports = ports
+		var data model.OpenLibertyServerXml
+		err = xml.Unmarshal(fileBytes, &data)
+		if err != nil {
+			continue
+		}
+		ports := utils.GetValidPorts([]string{data.HttpEndpoint.HttpPort, data.HttpEndpoint.HttpsPort})
+		if len(ports) > 0 {
+			component.Ports = ports
+			return
+		}
 	}
 }

--- a/pkg/apis/enricher/framework/java/quarkus_detector.go
+++ b/pkg/apis/enricher/framework/java/quarkus_detector.go
@@ -24,20 +24,6 @@ import (
 
 type QuarkusDetector struct{}
 
-type QuarkusApplicationYaml struct {
-	Quarkus QuarkusHttp `yaml:"quarkus,omitempty"`
-}
-
-type QuarkusHttp struct {
-	Http QuarkusHttpPort `yaml:"http,omitempty"`
-}
-
-type QuarkusHttpPort struct {
-	Port             int    `yaml:"port,omitempty"`
-	InsecureRequests string `yaml:"insecure-requests,omitempty"`
-	SSLPort          int    `yaml:"ssl-port,omitempty"`
-}
-
 func (q QuarkusDetector) GetSupportedFrameworks() []string {
 	return []string{"Quarkus"}
 }

--- a/pkg/apis/enricher/framework/java/quarkus_detector.go
+++ b/pkg/apis/enricher/framework/java/quarkus_detector.go
@@ -28,6 +28,29 @@ func (q QuarkusDetector) GetSupportedFrameworks() []string {
 	return []string{"Quarkus"}
 }
 
+func (q QuarkusDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.properties",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yml",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yaml",
+		},
+	}
+}
+
 // DoFrameworkDetection uses the groupId to check for the framework name
 func (q QuarkusDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFwk, _ := hasFramework(config, "io.quarkus", ""); hasFwk {
@@ -51,6 +74,7 @@ func (q QuarkusDetector) DoPortsDetection(component *model.Component, ctx *conte
 		component.Ports = ports
 		return
 	}
+
 	// check if port is set on .env file
 	insecureRequestEnabled := utils.GetStringValueFromEnvFile(component.Path, `QUARKUS_HTTP_INSECURE_REQUESTS=(\w*)`)
 	regexes := []string{`QUARKUS_HTTP_SSL_PORT=(\d*)`}
@@ -63,20 +87,13 @@ func (q QuarkusDetector) DoPortsDetection(component *model.Component, ctx *conte
 		return
 	}
 
-	applicationFile := utils.GetAnyApplicationFilePath(component.Path, []model.ApplicationFileInfo{
-		{
-			Dir:  "src/main/resources",
-			File: "application.properties",
-		},
-		{
-			Dir:  "src/main/resources",
-			File: "application.yml",
-		},
-		{
-			Dir:  "src/main/resources",
-			File: "application.yaml",
-		},
-	}, ctx)
+	appFileInfos := q.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	// case: no port found as env var. Look into source code.
+	applicationFile := utils.GetAnyApplicationFilePath(component.Path, appFileInfos, ctx)
 	if applicationFile == "" {
 		return
 	}
@@ -152,7 +169,7 @@ func getServerPortsFromQuarkusApplicationYamlFile(file string) ([]int, error) {
 	if err != nil {
 		return []int{}, err
 	}
-	var data QuarkusApplicationYaml
+	var data model.QuarkusApplicationYaml
 	err = yaml.Unmarshal(yamlFile, &data)
 	if err != nil {
 		return []int{}, err

--- a/pkg/apis/enricher/framework/java/spring_detector.go
+++ b/pkg/apis/enricher/framework/java/spring_detector.go
@@ -150,7 +150,7 @@ func getServerPortsFromYamlFile(file string) ([]int, error) {
 	if err != nil {
 		return []int{}, err
 	}
-	var data ApplicationProsServer
+	var data model.SpringApplicationProsServer
 	err = yaml.Unmarshal(yamlFile, &data)
 	if err != nil {
 		return []int{}, err

--- a/pkg/apis/enricher/framework/java/vertx_detector.go
+++ b/pkg/apis/enricher/framework/java/vertx_detector.go
@@ -56,21 +56,26 @@ func (v VertxDetector) DoPortsDetection(component *model.Component, ctx *context
 		return
 	}
 
-	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
-	if err != nil {
-		return
-	}
+	for _, appFileInfo := range appFileInfos {
+		fileBytes, err := utils.GetApplicationFileBytes(appFileInfo)
+		if err != nil {
+			continue
+		}
 
-	var data model.VertxConf
-	err = json.Unmarshal(fileBytes, &data)
-	if err != nil {
-		return
-	}
+		var data model.VertxConf
+		err = json.Unmarshal(fileBytes, &data)
+		if err != nil {
+			continue
+		}
 
-	if utils.IsValidPort(data.Port) {
-		component.Ports = []int{data.Port}
-	} else if utils.IsValidPort(data.ServerConfig.Port) {
-		component.Ports = []int{data.ServerConfig.Port}
-	}
+		if utils.IsValidPort(data.Port) {
+			component.Ports = []int{data.Port}
+			return
+		}
 
+		if utils.IsValidPort(data.ServerConfig.Port) {
+			component.Ports = []int{data.ServerConfig.Port}
+			return
+		}
+	}
 }

--- a/pkg/apis/enricher/framework/java/vertx_detector.go
+++ b/pkg/apis/enricher/framework/java/vertx_detector.go
@@ -30,14 +30,8 @@ func (v VertxDetector) GetApplicationFileInfos(componentPath string, ctx *contex
 		{
 			Context: ctx,
 			Root:    componentPath,
-			Dir:     "",
-			File:    "server.xml",
-		},
-		{
-			Context: ctx,
-			Root:    componentPath,
-			Dir:     "src/main/liberty/config",
-			File:    "server.xml",
+			Dir:     "src/main/conf",
+			File:    ".*.json",
 		},
 	}
 }

--- a/pkg/apis/enricher/framework/java/wildfly_detector.go
+++ b/pkg/apis/enricher/framework/java/wildfly_detector.go
@@ -51,28 +51,31 @@ func (w WildFlyDetector) DoPortsDetection(component *model.Component, ctx *conte
 	if len(appFileInfos) == 0 {
 		return
 	}
-	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
-	if err != nil {
-		return
-	}
 
-	var pom schema.Pom
-	err = xml.Unmarshal(fileBytes, &pom)
-	if err != nil {
-		return
-	}
+	for _, appFileInfo := range appFileInfos {
+		fileBytes, err := utils.GetApplicationFileBytes(appFileInfo)
+		if err != nil {
+			continue
+		}
 
-	portPlaceholder := GetPortsForJBossFrameworks(pom, "wildfly-maven-plugin", "org.wildfly.plugins")
-	if portPlaceholder == "" {
-		return
-	}
+		var pom schema.Pom
+		err = xml.Unmarshal(fileBytes, &pom)
+		if err != nil {
+			continue
+		}
 
-	if port, err := utils.GetValidPort(portPlaceholder); err == nil {
-		ports = append(ports, port)
-	}
+		portPlaceholder := GetPortsForJBossFrameworks(pom, "wildfly-maven-plugin", "org.wildfly.plugins")
+		if portPlaceholder == "" {
+			continue
+		}
 
-	if len(ports) > 0 {
-		component.Ports = ports
-		return
+		if port, err := utils.GetValidPort(portPlaceholder); err == nil {
+			ports = append(ports, port)
+		}
+
+		if len(ports) > 0 {
+			component.Ports = ports
+			return
+		}
 	}
 }

--- a/pkg/apis/enricher/framework/java/wildfly_detector.go
+++ b/pkg/apis/enricher/framework/java/wildfly_detector.go
@@ -13,19 +13,30 @@ package enricher
 
 import (
 	"context"
+	"encoding/xml"
 
 	"github.com/devfile/alizer/pkg/apis/model"
+	"github.com/devfile/alizer/pkg/schema"
 	"github.com/devfile/alizer/pkg/utils"
 )
 
 type WildFlyDetector struct{}
 
-func (o WildFlyDetector) GetSupportedFrameworks() []string {
+func (w WildFlyDetector) GetSupportedFrameworks() []string {
 	return []string{"WildFly"}
 }
 
+func (w WildFlyDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	files, err := utils.GetCachedFilePathsFromRoot(componentPath, ctx)
+	if err != nil {
+		return []model.ApplicationFileInfo{}
+	}
+	pomXML := utils.GetFile(&files, "pom.xml")
+	return utils.GenerateApplicationFileFromFilters([]string{pomXML}, componentPath, "", ctx)
+}
+
 // DoFrameworkDetection uses the groupId and artifactId to check for the framework name
-func (o WildFlyDetector) DoFrameworkDetection(language *model.Language, config string) {
+func (w WildFlyDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFwk, _ := hasFramework(config, "org.wildfly.plugins", "wildfly-maven-plugin"); hasFwk {
 		language.Frameworks = append(language.Frameworks, "WildFly")
 	}
@@ -33,15 +44,25 @@ func (o WildFlyDetector) DoFrameworkDetection(language *model.Language, config s
 
 // DoPortsDetection for wildfly fetches the pom.xml and tries to find any javaOpts under
 // the wildfly-maven-plugin profiles. If there is one it looks if jboss.http.port is defined.
-func (o WildFlyDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+func (w WildFlyDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	ports := []int{}
 	// Fetch the content of xml for this component
-	paths, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
+	appFileInfos := w.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
 	if err != nil {
 		return
 	}
-	pomXML := utils.GetFile(&paths, "pom.xml")
-	portPlaceholder := GetPortsForJBossFrameworks(pomXML, "wildfly-maven-plugin", "org.wildfly.plugins")
+
+	var pom schema.Pom
+	err = xml.Unmarshal(fileBytes, &pom)
+	if err != nil {
+		return
+	}
+
+	portPlaceholder := GetPortsForJBossFrameworks(pom, "wildfly-maven-plugin", "org.wildfly.plugins")
 	if portPlaceholder == "" {
 		return
 	}

--- a/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
@@ -24,6 +24,12 @@ func (n NextDetector) GetSupportedFrameworks() []string {
 	return []string{"Next"}
 }
 
+func (a NextDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	// Next.js enricher does not apply source code detection.
+	// It only detects ports from start/dev script
+	return []model.ApplicationFileInfo{}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (n NextDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "next") {

--- a/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
@@ -25,6 +25,17 @@ func (n NuxtDetector) GetSupportedFrameworks() []string {
 	return []string{"Nuxt"}
 }
 
+func (n NuxtDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "",
+			File:    "nuxt.config.js",
+		},
+	}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (n NuxtDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "nuxt") {
@@ -50,15 +61,16 @@ func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.
 	}
 
 	//check inside the nuxt.config.js file
-	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
-		{
-			Dir:  "",
-			File: "nuxt.config.js",
-		},
-	}, ctx)
+	appFileInfos := n.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
 	if err != nil {
 		return
 	}
+
 	re := regexp.MustCompile(`port:\s*(\d+)*`)
-	component.Ports = utils.FindAllPortsSubmatch(re, string(bytes), 1)
+	component.Ports = utils.FindAllPortsSubmatch(re, string(fileBytes), 1)
 }

--- a/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
@@ -45,6 +45,7 @@ func (n NuxtDetector) DoFrameworkDetection(language *model.Language, config stri
 
 // DoPortsDetection searches for the port in package.json, and nuxt.config.js
 func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	ports := []int{}
 	regexes := []string{`--port=(\d*)`}
 	// check if port is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)
@@ -66,11 +67,17 @@ func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.
 		return
 	}
 
-	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
-	if err != nil {
-		return
-	}
+	for _, appFileInfo := range appFileInfos {
+		fileBytes, err := utils.GetApplicationFileBytes(appFileInfo)
+		if err != nil {
+			continue
+		}
 
-	re := regexp.MustCompile(`port:\s*(\d+)*`)
-	component.Ports = utils.FindAllPortsSubmatch(re, string(fileBytes), 1)
+		re := regexp.MustCompile(`port:\s*(\d+)*`)
+		ports = utils.FindAllPortsSubmatch(re, string(fileBytes), 1)
+		if len(ports) > 0 {
+			component.Ports = ports
+			return
+		}
+	}
 }

--- a/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
@@ -28,7 +28,7 @@ func (r ReactJsDetector) GetSupportedFrameworks() []string {
 func (r ReactJsDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
 	// React.js enricher does not apply source code detection.
 	// It only detects ports from start script or env vars
-	return []model.ApplicationFileInfo{}
+	return nil
 }
 
 // DoFrameworkDetection uses a tag to check for the framework name

--- a/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
@@ -25,6 +25,12 @@ func (r ReactJsDetector) GetSupportedFrameworks() []string {
 	return []string{"React"}
 }
 
+func (r ReactJsDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	// React.js enricher does not apply source code detection.
+	// It only detects ports from start script or env vars
+	return []model.ApplicationFileInfo{}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (r ReactJsDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "react") {

--- a/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
@@ -24,6 +24,12 @@ func (s SvelteDetector) GetSupportedFrameworks() []string {
 	return []string{"Svelte"}
 }
 
+func (s SvelteDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	// Svelte.js enricher does not apply source code detection.
+	// It only detects ports from dev script
+	return []model.ApplicationFileInfo{}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (s SvelteDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "svelte") {

--- a/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
@@ -27,7 +27,7 @@ func (s SvelteDetector) GetSupportedFrameworks() []string {
 func (s SvelteDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
 	// Svelte.js enricher does not apply source code detection.
 	// It only detects ports from dev script
-	return []model.ApplicationFileInfo{}
+	return nil
 }
 
 // DoFrameworkDetection uses a tag to check for the framework name

--- a/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
@@ -25,6 +25,17 @@ func (v VueDetector) GetSupportedFrameworks() []string {
 	return []string{"Vue"}
 }
 
+func (v VueDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "",
+			File:    "vue.config.js",
+		},
+	}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (v VueDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "vue") {
@@ -62,15 +73,16 @@ func (v VueDetector) DoPortsDetection(component *model.Component, ctx *context.C
 	}
 
 	//check inside the vue.config.js file
-	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
-		{
-			Dir:  "",
-			File: "vue.config.js",
-		},
-	}, ctx)
+	appFileInfos := v.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
 	if err != nil {
 		return
 	}
+
 	re := regexp.MustCompile(`port:\s*(\d+)*`)
-	component.Ports = utils.FindAllPortsSubmatch(re, string(bytes), 1)
+	component.Ports = utils.FindAllPortsSubmatch(re, string(fileBytes), 1)
 }

--- a/pkg/apis/enricher/framework/php/laravel_detector.go
+++ b/pkg/apis/enricher/framework/php/laravel_detector.go
@@ -24,6 +24,12 @@ func (d LaravelDetector) GetSupportedFrameworks() []string {
 	return []string{"Laravel"}
 }
 
+func (d LaravelDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	// laravel enricher does not apply source code detection.
+	// It only detects ports declared as env vars
+	return []model.ApplicationFileInfo{}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 func (d LaravelDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFramework(config, "laravel") {

--- a/pkg/apis/enricher/framework/php/laravel_detector.go
+++ b/pkg/apis/enricher/framework/php/laravel_detector.go
@@ -27,7 +27,7 @@ func (d LaravelDetector) GetSupportedFrameworks() []string {
 func (d LaravelDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
 	// laravel enricher does not apply source code detection.
 	// It only detects ports declared as env vars
-	return []model.ApplicationFileInfo{}
+	return nil
 }
 
 // DoFrameworkDetection uses a tag to check for the framework name

--- a/pkg/apis/enricher/framework/python/django_detector.go
+++ b/pkg/apis/enricher/framework/python/django_detector.go
@@ -25,46 +25,58 @@ func (d DjangoDetector) GetSupportedFrameworks() []string {
 	return []string{"Django"}
 }
 
+func (d DjangoDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "",
+			File:    "manage.py",
+		},
+	}
+}
+
+func (d DjangoDetector) GetDjangoFilenames() []string {
+	return []string{"manage.py", "urls.py", "wsgi.py", "asgi.py"}
+}
+
+func (d DjangoDetector) GetConfigDjangoFilenames() []string {
+	return []string{"requirements.txt", "pyproject.toml"}
+}
+
 // DoFrameworkDetection uses a tag to check for the framework name
 // with django files and django config files
 func (d DjangoDetector) DoFrameworkDetection(language *model.Language, files *[]string) {
-	managePy := utils.GetFile(files, "manage.py")
-	urlsPy := utils.GetFile(files, "urls.py")
-	wsgiPy := utils.GetFile(files, "wsgi.py")
-	asgiPy := utils.GetFile(files, "asgi.py")
-	requirementsTxt := utils.GetFile(files, "requirements.txt")
-	projectToml := utils.GetFile(files, "pyproject.toml")
-
 	var djangoFiles []string
 	var configDjangoFiles []string
-	utils.AddToArrayIfValueExist(&djangoFiles, managePy)
-	utils.AddToArrayIfValueExist(&djangoFiles, urlsPy)
-	utils.AddToArrayIfValueExist(&djangoFiles, wsgiPy)
-	utils.AddToArrayIfValueExist(&djangoFiles, asgiPy)
-	utils.AddToArrayIfValueExist(&configDjangoFiles, requirementsTxt)
-	utils.AddToArrayIfValueExist(&configDjangoFiles, projectToml)
+
+	for _, filename := range d.GetDjangoFilenames() {
+		filePy := utils.GetFile(files, filename)
+		utils.AddToArrayIfValueExist(&djangoFiles, filePy)
+	}
+
+	for _, filename := range d.GetConfigDjangoFilenames() {
+		configFile := utils.GetFile(files, filename)
+		utils.AddToArrayIfValueExist(&configDjangoFiles, configFile)
+	}
 
 	if hasFramework(&djangoFiles, "from django.") || hasFramework(&configDjangoFiles, "django") || hasFramework(&configDjangoFiles, "Django") {
 		language.Frameworks = append(language.Frameworks, "Django")
 	}
 }
 
-type ApplicationPropertiesFile struct {
-	Dir  string
-	File string
-}
-
 // DoPortsDetection searches for the port in /manage.py
 func (d DjangoDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
-	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
-		{
-			Dir:  "",
-			File: "manage.py",
-		},
-	}, ctx)
+	appFileInfos := d.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	fileBytes, err := utils.GetApplicationFileBytes(appFileInfos[0])
 	if err != nil {
 		return
 	}
+
 	re := regexp.MustCompile(`.default_port\s*=\s*"([^"]*)`)
-	component.Ports = utils.FindAllPortsSubmatch(re, string(bytes), 1)
+	component.Ports = utils.FindAllPortsSubmatch(re, string(fileBytes), 1)
 }

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -24,21 +24,25 @@ const (
 
 // All models inside model.go are sorted by name A-Z
 
+// AngularCliJson represents the angular-cli.json file
 type AngularCliJson struct {
 	Defaults struct {
 		Serve AngularHostPort `json:"serve"`
 	} `json:"defaults"`
 }
 
+// AngularHostPort represents the value of AngularCliJson.Defaults.Serve
 type AngularHostPort struct {
 	Host string `json:"host"`
 	Port int    `json:"port"`
 }
 
+// AngularJson represents angular.json
 type AngularJson struct {
 	Projects map[string]AngularProjectBody `json:"projects"`
 }
 
+// AngularProjectBody represents the value of each key of the map for AngularJson.Projects
 type AngularProjectBody struct {
 	Architect struct {
 		Serve struct {
@@ -47,41 +51,81 @@ type AngularProjectBody struct {
 	} `json:"architect"`
 }
 
+// ApplicationFileInfo is the main struct used to select potential application files
+// for detectors
 type ApplicationFileInfo struct {
+	// Context is the given context
 	Context *context.Context
-	Root    string
-	Dir     string
-	File    string
+
+	// Root is the root path of the component
+	Root string
+
+	// Dir is the directory of the application file
+	Dir string
+
+	// File is the filename of the application file
+	File string
 }
 
+// Component represents every component detected from analysis process
 type Component struct {
-	Name      string
-	Path      string
+	// Name is the name of the component
+	Name string
+
+	// Path is the root path of the component
+	Path string
+
+	// Languages is the slice of languages detected inside the component
 	Languages []Language
-	Ports     []int
+
+	// Ports is the slice of integers (port values) detected
+	Ports []int
 }
 
+// DetectionSettings represents the required settings for component detection
 type DetectionSettings struct {
-	BasePath              string
+	// BasePath is the root path we need to apply detection process
+	BasePath string
+
+	// PortDetectionStrategy is the list of areas that we will apply port detection
+	// Accepted values can be found at PortDetectionAlgorithm
 	PortDetectionStrategy []PortDetectionAlgorithm
 }
 
+// DevfileFilter represents all filters passed to registry api upon requests
 type DevfileFilter struct {
+	// MinSchemaVersion is the minimum schemaVersion of the fetched devfiles
 	MinSchemaVersion string
+
+	// MaxSchemaVersion is the maximum schemaVersion of the fetched devfiles
 	MaxSchemaVersion string
 }
 
+// DevfileScore represents the score that each devfile gets upon devfile matching process
 type DevfileScore struct {
+	// DevfileIndex is the index of the fetched registry stacks slice
 	DevfileIndex int
-	Score        int
+
+	// Score is the score that a devfile has. The biggest score gets matched with a given source code
+	Score int
 }
 
+// DevfileType represents a devfile.y(a)ml file
 type DevfileType struct {
-	Name        string
-	Language    string
+	// Name is the name of a devfile
+	Name string
+
+	// Language is the language of a devfile
+	Language string
+
+	// ProjectType is the projectType of a devfile
 	ProjectType string
-	Tags        []string
-	Versions    []Version
+
+	// Tags is a slice of tags of a devfile
+	Tags []string
+
+	// Versions is a slice of versions of a devfile
+	Versions []Version
 }
 
 // EnvVar represents an environment variable with a name and a corresponding value.
@@ -93,16 +137,31 @@ type EnvVar struct {
 	Value string
 }
 
+// Language represents every language detected from language analysis process
 type Language struct {
-	Name                    string
-	Aliases                 []string
-	Weight                  float64
-	Frameworks              []string
-	Tools                   []string
-	CanBeComponent          bool
+	// Name is the name of the language
+	Name string
+
+	// Aliases is the slice of aliases for this language
+	Aliases []string
+
+	// Weight is the float value which shows the importance of this language inside a given source code
+	Weight float64
+
+	// Frameworks is the slice of frameworks detected for this language
+	Frameworks []string
+
+	// Tools is the slice of tools detected for this language
+	Tools []string
+
+	// CanBeComponent is the bool value shows if this language can be detected as component
+	CanBeComponent bool
+
+	// CanBeContainerComponent is the bool value shows if this language can be detected as container component
 	CanBeContainerComponent bool
 }
 
+// MicronautApplicationProps represents the application.properties file of micronaut applications
 type MicronautApplicationProps struct {
 	Micronaut struct {
 		Server struct {
@@ -115,6 +174,7 @@ type MicronautApplicationProps struct {
 	} `yaml:"micronaut,omitempty"`
 }
 
+// OpenLibertyServerXml represents the server.xml file inside an open liberty application
 type OpenLibertyServerXml struct {
 	HttpEndpoint struct {
 		HttpPort  string `xml:"httpPort,attr"`
@@ -122,37 +182,54 @@ type OpenLibertyServerXml struct {
 	} `xml:"httpEndpoint"`
 }
 
+// PortDetectionAlgorithm represents one of port detection algorithm values
 type PortDetectionAlgorithm int
 
+// PortMatchRule represents a rule for port matching with a given regex and a string to replace
 type PortMatchRule struct {
-	Regex     *regexp.Regexp
+	// Regex is the regexp.Regexp value which will be used to match ports
+	Regex *regexp.Regexp
+
+	// ToReplace is the string value which will be replaced once the Regex is matched
 	ToReplace string
 }
 
+// PortMatchRules represents a struct of rules and subrules for port matching
 type PortMatchRules struct {
+	// MatchIndexRegexes is a slice of PortMatchRule
 	MatchIndexRegexes []PortMatchRule
-	MatchRegexes      []PortMatchSubRule
+
+	// MatchRegexes is a slice of PortMatchSubRule
+	MatchRegexes []PortMatchSubRule
 }
 
+// PortMatchSubRule represents a sub rule for port matching
 type PortMatchSubRule struct {
-	Regex    *regexp.Regexp
+	// Regex is the primary regexp.Regexp value for the sub rule
+	Regex *regexp.Regexp
+
+	// Regex is the secondary regexp.Regexp value for the sub rule
 	SubRegex *regexp.Regexp
 }
 
+// QuarkusApplicationYaml represents the application.yaml used for quarkus applications
 type QuarkusApplicationYaml struct {
 	Quarkus QuarkusHttp `yaml:"quarkus,omitempty"`
 }
 
+// QuarkusHttp represents the port field from application.yaml of quarkus applications
 type QuarkusHttp struct {
 	Http QuarkusHttpPort `yaml:"http,omitempty"`
 }
 
+// QuarkusHttpPort represents the port value from application.yaml of quarkus applications
 type QuarkusHttpPort struct {
 	Port             int    `yaml:"port,omitempty"`
 	InsecureRequests string `yaml:"insecure-requests,omitempty"`
 	SSLPort          int    `yaml:"ssl-port,omitempty"`
 }
 
+// SpringApplicationProsServer represents the application.properties file used for spring applications
 type SpringApplicationProsServer struct {
 	Server struct {
 		Port int `yaml:"port,omitempty"`
@@ -162,17 +239,25 @@ type SpringApplicationProsServer struct {
 	} `yaml:"server,omitempty"`
 }
 
+// Version represents a version of a devfile
 type Version struct {
+	// SchemaVersion is the schemaVersion value of a devfile version
 	SchemaVersion string
-	Default       bool
-	Version       string
+
+	// Default is the default value of a devfile version
+	Default bool
+
+	// Version is the version tag of a devfile version
+	Version string
 }
 
+// VertxConf represents the config file for vertx applications
 type VertxConf struct {
 	Port         int                `json:"http.port,omitempty"`
 	ServerConfig VertexServerConfig `json:"http.server,omitempty"`
 }
 
+// VertexServerConfig represents the server config file for vertx applications
 type VertexServerConfig struct {
 	Port int `json:"http.server.port,omitempty"`
 }

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -72,6 +72,15 @@ type ApplicationFileInfo struct {
 	File    string
 }
 
+type ApplicationProsServer struct {
+	Server struct {
+		Port int `yaml:"port,omitempty"`
+		Http struct {
+			Port int `yaml:"port,omitempty"`
+		} `yaml:"http,omitempty"`
+	} `yaml:"server,omitempty"`
+}
+
 type PortMatchRules struct {
 	MatchIndexRegexes []PortMatchRule
 	MatchRegexes      []PortMatchSubRule

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -84,11 +84,6 @@ type DevfileType struct {
 	Versions    []Version
 }
 
-type DjangoApplicationPropertiesFile struct {
-	Dir  string
-	File string
-}
-
 // EnvVar represents an environment variable with a name and a corresponding value.
 type EnvVar struct {
 	// Name is the name of the environment variable.

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -11,7 +11,10 @@
 
 package model
 
-import "regexp"
+import (
+	"context"
+	"regexp"
+)
 
 type PortDetectionAlgorithm int
 
@@ -63,8 +66,10 @@ type DevfileFilter struct {
 }
 
 type ApplicationFileInfo struct {
-	Dir  string
-	File string
+	Context *context.Context
+	Root    string
+	Dir     string
+	File    string
 }
 
 type PortMatchRules struct {

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -72,6 +72,29 @@ type ApplicationFileInfo struct {
 	File    string
 }
 
+type AngularCliJson struct {
+	Defaults struct {
+		Serve AngularHostPort `json:"serve"`
+	} `json:"defaults"`
+}
+
+type AngularJson struct {
+	Projects map[string]AngularProjectBody `json:"projects"`
+}
+
+type AngularProjectBody struct {
+	Architect struct {
+		Serve struct {
+			Options AngularHostPort `json:"options"`
+		} `json:"serve"`
+	} `json:"architect"`
+}
+
+type AngularHostPort struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
 type SpringApplicationProsServer struct {
 	Server struct {
 		Port int `yaml:"port,omitempty"`

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -16,66 +16,23 @@ import (
 	"regexp"
 )
 
-type PortDetectionAlgorithm int
-
 const (
 	DockerFile PortDetectionAlgorithm = 0
 	Compose    PortDetectionAlgorithm = 1
 	Source     PortDetectionAlgorithm = 2
 )
 
-type DetectionSettings struct {
-	BasePath              string
-	PortDetectionStrategy []PortDetectionAlgorithm
-}
-
-type Language struct {
-	Name                    string
-	Aliases                 []string
-	Weight                  float64
-	Frameworks              []string
-	Tools                   []string
-	CanBeComponent          bool
-	CanBeContainerComponent bool
-}
-
-type Component struct {
-	Name      string
-	Path      string
-	Languages []Language
-	Ports     []int
-}
-
-type Version struct {
-	SchemaVersion string
-	Default       bool
-	Version       string
-}
-
-type DevfileType struct {
-	Name        string
-	Language    string
-	ProjectType string
-	Tags        []string
-	Versions    []Version
-}
-
-type DevfileFilter struct {
-	MinSchemaVersion string
-	MaxSchemaVersion string
-}
-
-type ApplicationFileInfo struct {
-	Context *context.Context
-	Root    string
-	Dir     string
-	File    string
-}
+// All models inside model.go are sorted by name A-Z
 
 type AngularCliJson struct {
 	Defaults struct {
 		Serve AngularHostPort `json:"serve"`
 	} `json:"defaults"`
+}
+
+type AngularHostPort struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
 }
 
 type AngularJson struct {
@@ -90,38 +47,46 @@ type AngularProjectBody struct {
 	} `json:"architect"`
 }
 
-type AngularHostPort struct {
-	Host string `json:"host"`
-	Port int    `json:"port"`
+type ApplicationFileInfo struct {
+	Context *context.Context
+	Root    string
+	Dir     string
+	File    string
 }
 
-type SpringApplicationProsServer struct {
-	Server struct {
-		Port int `yaml:"port,omitempty"`
-		Http struct {
-			Port int `yaml:"port,omitempty"`
-		} `yaml:"http,omitempty"`
-	} `yaml:"server,omitempty"`
+type Component struct {
+	Name      string
+	Path      string
+	Languages []Language
+	Ports     []int
 }
 
-type PortMatchRules struct {
-	MatchIndexRegexes []PortMatchRule
-	MatchRegexes      []PortMatchSubRule
+type DetectionSettings struct {
+	BasePath              string
+	PortDetectionStrategy []PortDetectionAlgorithm
 }
 
-type PortMatchRule struct {
-	Regex     *regexp.Regexp
-	ToReplace string
-}
-
-type PortMatchSubRule struct {
-	Regex    *regexp.Regexp
-	SubRegex *regexp.Regexp
+type DevfileFilter struct {
+	MinSchemaVersion string
+	MaxSchemaVersion string
 }
 
 type DevfileScore struct {
 	DevfileIndex int
 	Score        int
+}
+
+type DevfileType struct {
+	Name        string
+	Language    string
+	ProjectType string
+	Tags        []string
+	Versions    []Version
+}
+
+type DjangoApplicationPropertiesFile struct {
+	Dir  string
+	File string
 }
 
 // EnvVar represents an environment variable with a name and a corresponding value.
@@ -131,6 +96,16 @@ type EnvVar struct {
 
 	// Value is the value associated with the environment variable.
 	Value string
+}
+
+type Language struct {
+	Name                    string
+	Aliases                 []string
+	Weight                  float64
+	Frameworks              []string
+	Tools                   []string
+	CanBeComponent          bool
+	CanBeContainerComponent bool
 }
 
 type MicronautApplicationProps struct {
@@ -152,8 +127,21 @@ type OpenLibertyServerXml struct {
 	} `xml:"httpEndpoint"`
 }
 
-type VertexServerConfig struct {
-	Port int `json:"http.server.port,omitempty"`
+type PortDetectionAlgorithm int
+
+type PortMatchRule struct {
+	Regex     *regexp.Regexp
+	ToReplace string
+}
+
+type PortMatchRules struct {
+	MatchIndexRegexes []PortMatchRule
+	MatchRegexes      []PortMatchSubRule
+}
+
+type PortMatchSubRule struct {
+	Regex    *regexp.Regexp
+	SubRegex *regexp.Regexp
 }
 
 type QuarkusApplicationYaml struct {
@@ -170,7 +158,26 @@ type QuarkusHttpPort struct {
 	SSLPort          int    `yaml:"ssl-port,omitempty"`
 }
 
+type SpringApplicationProsServer struct {
+	Server struct {
+		Port int `yaml:"port,omitempty"`
+		Http struct {
+			Port int `yaml:"port,omitempty"`
+		} `yaml:"http,omitempty"`
+	} `yaml:"server,omitempty"`
+}
+
+type Version struct {
+	SchemaVersion string
+	Default       bool
+	Version       string
+}
+
 type VertxConf struct {
 	Port         int                `json:"http.port,omitempty"`
 	ServerConfig VertexServerConfig `json:"http.server,omitempty"`
+}
+
+type VertexServerConfig struct {
+	Port int `json:"http.server.port,omitempty"`
 }

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -100,3 +100,36 @@ type EnvVar struct {
 	// Value is the value associated with the environment variable.
 	Value string
 }
+
+type MicronautApplicationProps struct {
+	Micronaut struct {
+		Server struct {
+			Port int `yaml:"port,omitempty"`
+			SSL  struct {
+				Enabled bool `yaml:"enabled,omitempty"`
+				Port    int  `yaml:"port,omitempty"`
+			} `yaml:"ssl,omitempty"`
+		} `yaml:"server,omitempty"`
+	} `yaml:"micronaut,omitempty"`
+}
+
+type ServerXml struct {
+	HttpEndpoint struct {
+		HttpPort  string `xml:"httpPort,attr"`
+		HttpsPort string `xml:"httpsPort,attr"`
+	} `xml:"httpEndpoint"`
+}
+
+type QuarkusApplicationYaml struct {
+	Quarkus QuarkusHttp `yaml:"quarkus,omitempty"`
+}
+
+type QuarkusHttp struct {
+	Http QuarkusHttpPort `yaml:"http,omitempty"`
+}
+
+type QuarkusHttpPort struct {
+	Port             int    `yaml:"port,omitempty"`
+	InsecureRequests string `yaml:"insecure-requests,omitempty"`
+	SSLPort          int    `yaml:"ssl-port,omitempty"`
+}

--- a/pkg/apis/model/model.go
+++ b/pkg/apis/model/model.go
@@ -72,7 +72,7 @@ type ApplicationFileInfo struct {
 	File    string
 }
 
-type ApplicationProsServer struct {
+type SpringApplicationProsServer struct {
 	Server struct {
 		Port int `yaml:"port,omitempty"`
 		Http struct {
@@ -122,11 +122,15 @@ type MicronautApplicationProps struct {
 	} `yaml:"micronaut,omitempty"`
 }
 
-type ServerXml struct {
+type OpenLibertyServerXml struct {
 	HttpEndpoint struct {
 		HttpPort  string `xml:"httpPort,attr"`
 		HttpsPort string `xml:"httpsPort,attr"`
 	} `xml:"httpEndpoint"`
+}
+
+type VertexServerConfig struct {
+	Port int `json:"http.server.port,omitempty"`
 }
 
 type QuarkusApplicationYaml struct {
@@ -141,4 +145,9 @@ type QuarkusHttpPort struct {
 	Port             int    `yaml:"port,omitempty"`
 	InsecureRequests string `yaml:"insecure-requests,omitempty"`
 	SSLPort          int    `yaml:"ssl-port,omitempty"`
+}
+
+type VertxConf struct {
+	Port         int                `json:"http.port,omitempty"`
+	ServerConfig VertexServerConfig `json:"http.server,omitempty"`
 }

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -606,6 +606,16 @@ func GetApplicationFileBytes(propsFile model.ApplicationFileInfo) ([]byte, error
 	return bytes, nil
 }
 
+// GetApplicationFileInfo returns an item from a slice of applicationFileInfos if it matches the given filename
+func GetApplicationFileInfo(propsFiles []model.ApplicationFileInfo, filename string) (model.ApplicationFileInfo, error) {
+	for _, propsFile := range propsFiles {
+		if propsFile.File == filename {
+			return propsFile, nil
+		}
+	}
+	return model.ApplicationFileInfo{}, fmt.Errorf("No ApplicationFileInfo found")
+}
+
 // ReadAnyApplicationFileExactMatch returns a byte slice if the exact given file exists in the directory.
 func ReadAnyApplicationFileExactMatch(root string, propsFiles []model.ApplicationFileInfo) ([]byte, error) {
 	return readAnyApplicationFile(root, propsFiles, true, nil)

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -610,7 +610,7 @@ func GetApplicationFileInfo(propsFiles []model.ApplicationFileInfo, filename str
 			return propsFile, nil
 		}
 	}
-	return model.ApplicationFileInfo{}, fmt.Errorf("No ApplicationFileInfo found")
+	return model.ApplicationFileInfo{}, fmt.Errorf("no ApplicationFileInfo found")
 }
 
 // ReadAnyApplicationFileExactMatch returns a byte slice if the exact given file exists in the directory.

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -66,16 +66,6 @@ func GetFile(filePaths *[]string, wantedFile string) string {
 	return ""
 }
 
-// HasFile checks if the file is in a filePaths path.
-func HasFile(files *[]string, wantedFile string) bool {
-	for _, path := range *files {
-		if IsPathOfWantedFile(path, wantedFile) {
-			return true
-		}
-	}
-	return false
-}
-
 // IsPathOfWantedFile checks if the file is in the path.
 func IsPathOfWantedFile(path string, wantedFile string) bool {
 	_, file := filepath.Split(path)
@@ -310,6 +300,7 @@ func GetFilePathsInRoot(root string) ([]string, error) {
 	return files, nil
 }
 
+// ConvertPropertiesFileAsPathToMap fetches a file from a given path and transforms it into a map
 func ConvertPropertiesFileAsPathToMap(path string) (map[string]string, error) {
 	bytes, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
@@ -318,6 +309,7 @@ func ConvertPropertiesFileAsPathToMap(path string) (map[string]string, error) {
 	return ConvertPropertiesFileToMap(bytes)
 }
 
+// ConvertPropertiesFileAsPathToMap transforms a slice of bytes it into a map
 func ConvertPropertiesFileToMap(fileInBytes []byte) (map[string]string, error) {
 	config := map[string]string{}
 	scanner := bufio.NewScanner(bytes.NewReader(fileInBytes))
@@ -563,6 +555,9 @@ func GetAnyApplicationFilePathExactMatch(root string, propsFiles []model.Applica
 	return ""
 }
 
+// GenerateApplicationFileFromFilters generates a slice of model.ApplicationFileInfo
+// from a given list of files and the root path of a component. If suffix exists
+// it generates items only for files ending with this suffix.
 func GenerateApplicationFileFromFilters(files []string, path string, suffix string, ctx *context.Context) []model.ApplicationFileInfo {
 	applicationFileInfos := []model.ApplicationFileInfo{}
 	for _, file := range files {
@@ -583,6 +578,8 @@ func GenerateApplicationFileFromFilters(files []string, path string, suffix stri
 	return applicationFileInfos
 }
 
+// GetApplicationFileContents returns a slice of strings for all file contents found for a given
+// slice of ApplicationFileInfo.
 func GetApplicationFileContents(appFileInfos []model.ApplicationFileInfo) ([]string, error) {
 	fileContents := []string{}
 	for _, appFileInfo := range appFileInfos {
@@ -635,6 +632,7 @@ func readAnyApplicationFile(root string, propsFiles []model.ApplicationFileInfo,
 	return nil, errors.New("no file found")
 }
 
+// FindPortSubMatch returns a port number in case it finds one for a given regex group
 func FindPortSubmatch(re *regexp.Regexp, text string, group int) int {
 	potentialPortGroup := FindPotentialPortGroup(re, text, group)
 	if potentialPortGroup != "" {
@@ -645,6 +643,7 @@ func FindPortSubmatch(re *regexp.Regexp, text string, group int) int {
 	return -1
 }
 
+// FindPotentialPortGroup returns a placeholder for port if is found
 func FindPotentialPortGroup(re *regexp.Regexp, text string, group int) string {
 	if text != "" {
 		matches := re.FindStringSubmatch(text)
@@ -655,6 +654,7 @@ func FindPotentialPortGroup(re *regexp.Regexp, text string, group int) string {
 	return ""
 }
 
+// FindAllPortsSubmatch returns a slice of port int values, matching a regex inside a given text
 func FindAllPortsSubmatch(re *regexp.Regexp, text string, group int) []int {
 	var ports []int
 	if text != "" {
@@ -671,6 +671,8 @@ func FindAllPortsSubmatch(re *regexp.Regexp, text string, group int) []int {
 	return ports
 }
 
+// GetPortValueFromEnvFile returns the first port value of a slice of port values
+// declared from env var files.
 func GetPortValueFromEnvFile(root string, regex string) int {
 	ports := GetPortValuesFromEnvFile(root, []string{regex})
 	if len(ports) > 0 {
@@ -679,6 +681,7 @@ func GetPortValueFromEnvFile(root string, regex string) int {
 	return -1
 }
 
+// GetPortValuesFromEnvFile returns all port values found inside an env var file
 func GetPortValuesFromEnvFile(root string, regexes []string) []int {
 	var ports []int
 	text, err := getEnvFileContent(root)
@@ -698,6 +701,7 @@ func GetPortValuesFromEnvFile(root string, regexes []string) []int {
 	return ports
 }
 
+// GetStringValueFromEnvFile returns port values as string from env file
 func GetStringValueFromEnvFile(root string, regex string) string {
 	text, err := getEnvFileContent(root)
 	if err != nil {
@@ -727,6 +731,7 @@ var getEnvFileContent = func(root string) (string, error) {
 	return string(bytes), nil
 }
 
+// NormalizeSplit splits a filepath into dir and filename
 func NormalizeSplit(file string) (string, string) {
 	dir, fileName := filepath.Split(file)
 	if dir == "" {

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -566,7 +566,7 @@ func GetAnyApplicationFilePathExactMatch(root string, propsFiles []model.Applica
 func GenerateApplicationFileFromFilters(files []string, path string, suffix string, ctx *context.Context) []model.ApplicationFileInfo {
 	applicationFileInfos := []model.ApplicationFileInfo{}
 	for _, file := range files {
-		if strings.HasSuffix(file, ".go") {
+		if strings.HasSuffix(file, suffix) {
 			cleanPath := filepath.Clean(file)
 			filename := filepath.Base(cleanPath)
 			tmpDir := strings.ReplaceAll(file, path, "")
@@ -586,9 +586,9 @@ func GenerateApplicationFileFromFilters(files []string, path string, suffix stri
 func GetApplicationFileContents(appFileInfos []model.ApplicationFileInfo) ([]string, error) {
 	fileContents := []string{}
 	for _, appFileInfo := range appFileInfos {
-		fileContent, err := ReadAnyApplicationFile(appFileInfo)
+		fileContent, err := GetApplicationFileBytes(appFileInfo)
 		if err == nil {
-			fileContents = append(fileContents, fileContent)
+			fileContents = append(fileContents, string(fileContent))
 		}
 	}
 	if len(fileContents) == 0 {
@@ -597,13 +597,13 @@ func GetApplicationFileContents(appFileInfos []model.ApplicationFileInfo) ([]str
 	return fileContents, nil
 }
 
-// ReadAnyApplicationFile returns a the content of a file if it exists in the directory and the given file name is a substring.
-func ReadAnyApplicationFile(propsFile model.ApplicationFileInfo) (string, error) {
+// GetApplicationFileBytes returns a slice of bytes of a file if it exists in the directory and the given file name is a substring.
+func GetApplicationFileBytes(propsFile model.ApplicationFileInfo) ([]byte, error) {
 	bytes, err := readAnyApplicationFile(propsFile.Root, []model.ApplicationFileInfo{propsFile}, false, propsFile.Context)
 	if err != nil {
-		return "", fmt.Errorf("error: %s", err)
+		return bytes, fmt.Errorf("error: %s", err)
 	}
-	return string(bytes), nil
+	return bytes, nil
 }
 
 // ReadAnyApplicationFileExactMatch returns a byte slice if the exact given file exists in the directory.

--- a/pkg/utils/testdata/test.properties
+++ b/pkg/utils/testdata/test.properties
@@ -1,0 +1,3 @@
+key1=value1
+key2=value2
+key3=value3


### PR DESCRIPTION
## What does this PR do?

This PR introduces new functionality for every detector in order to ensure a consistent way of picking files for port detection. It also adds more comments, the required unit tests and updates to the documentation.

### Updates
[Consistency]
* The `ApplicationFileInfo` model is expanded to contain the component path and the context. That way it can be the main model used to identify files that may contain information about port detection.

* In every `detector` we add the `GetApplicationFileInfos` which will return specific `ApplicationFileInfo` for every framework.

[Performance]
* For detectors which are looking inside the entire component to find source code files in order detect ports, the `GenerateApplicationFileFromFilters` func has been created. This way we are passing a search keyword in order to go through specific files. For example, we are passing `".go"` for all golang frameworks as, for port detection, we are interested only for golang files.

[Other Updates]
*  As each detector has different functionality for port detection, the `GetApplicationFileContents` and `GetApplicationFileBytes` in order to fetch the content of each application file as `string` or `bytes`.
* All models `types` from detector have been moved to `model.go` and sorted by name. This way we have a specific place to store all model's code and not have them spread around different modules. 
* Further refactoring has been made to `flaskdetector` and `djangodetector` to ensure that we are looping through application files and not picking them one by one.

### Results
1. Performance wise, for a big project with many components (e.g. https://github.com/openshift/hypershift) we can see big difference in the execution time. The main reason is that for many detectors we are filtering the files that we are parsing in order to detect ports. The results:
```bash
# old
$ time ./alizer component ~/github/alizer-tests/hypershift/
...
real	0m4,043s
user	0m4,281s
sys	0m0,368s

# new
time ./alizer component ~/github/alizer-tests/hypershift/
...
real	0m2,556s
user	0m2,909s
sys	0m0,318s
```

2. With the new way of defining potential application files we need only to add an item to every detector's `GetApplicationFileInfos` and not update the whole `DoPortDetection` func.

3. Ensuring that all models are stored in the same place and they have detailed naming. For example, the `ServerXml` from `OpenLibertyDetector` has been moved to `model.go` and renamed to `OpenLibertyServerXml`, in order to be easier identified and found.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1151

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
