### PR TITLE
chore: remove deprecated ioutil dependency

### DIFF
--- a/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -15,7 +15,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +66,7 @@ func getFrameworks(configFilePath string) string {
 	if err != nil {
 		return ""
 	}
-	byteValue, _ := ioutil.ReadAll(xmlFile)
+	byteValue, _ := io.ReadAll(xmlFile)
 
 	var proj schema.DotNetProject
 	err = xml.Unmarshal(byteValue, &proj)

--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -254,7 +254,7 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 		return []model.DevfileType{}, errors.New("unable to fetch devfiles from the registry")
 	}
 
-	body, err2 := ioutil.ReadAll(resp.Body)
+	body, err2 := io.ReadAll(resp.Body)
 	if err2 != nil {
 		return []model.DevfileType{}, errors.New("unable to fetch devfiles from the registry")
 	}

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -390,9 +390,17 @@ func GetValidPortsFromEnvDockerfile(envs []string, envVars []model.EnvVar) []int
 // Note that hidden files and directories (starting with a dot, e.g., '.git') are ignored while traversing the 'root' directory.
 func GetLocations(root string) []string {
 	locations := []string{"Dockerfile", "Containerfile", "dockerfile", "containerfile"}
-	dirItems, err := ioutil.ReadDir(root)
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		return locations
+	}
+	dirItems := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return locations
+		}
+		dirItems = append(dirItems, info)
 	}
 	for _, item := range dirItems {
 		if strings.HasPrefix(item.Name(), ".") {

--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/devfile/alizer/pkg/apis/model"
@@ -118,7 +118,7 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 		return []StarterProject{}, fmt.Errorf("unable to fetch starter project from registry %s. code: %d", url, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []StarterProject{}, fmt.Errorf("unable to read body from response - error: %s", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Removes deprecated ioutil dependency in 4 files listed below.
% find . -name "*.go" -type f -print | xargs grep /ioutil
./test/check_registry/check_registry.go:	"io/ioutil"
./pkg/apis/enricher/framework/dotnet/dotnet_detector.go:	"io/ioutil"
./pkg/apis/recognizer/devfile_recognizer.go:	"io/ioutil"
./pkg/utils/detector.go:	"io/ioutil"

### Which issue(s) does this PR fix

Partial fix for devfile/api#1257

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
os.ReadDir replacement for ioutil.ReadDir requires looping through []fs.DirEntry to access []fs.FileInfo. Consider revising error handling on this loop, I copied the previous error handling from the call to ioutil.ReadDir