### PR TITLE
Add golangci-lint linter to enforce that the `io/ioutil` package is not used anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Run Go tests
         run: make test
 
+      - name: Lint
+        run: |
+          make lint_install
+          make lint
+
       - name: Run Gosec Security Scanner
         run: |
           make gosec_install

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,44 @@
+# Refer to golangci-lint's reference config file for more options and information:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
+
+  # Allowed values: readonly|vendor|mod
+  # By default, it isn't set.
+  modules-download-mode: readonly
+
+  skip-dirs:
+    - resources/projects
+
+linters:
+  # Disable all linters.
+  # Default: false
+  # TODO(rm3l): all default linters are disabled in the context of https://github.com/devfile/api/issues/1257 (to just enforce that io/ioutil is not used anymore),
+  #   but we should think about enabling all the default linters and fix the issues reported.
+  disable-all: true
+  enable:
+    # Go linter that checks if package imports are in a list of acceptable packages
+    - depguard
+
+linters-settings:
+  depguard:
+    rules:
+      # Name of a rule.
+      main:
+        deny:
+          - pkg: "io/ioutil"
+            desc: "Deprecated since Go 1.16. Use the implementations from 'io' or 'os' packages instead."
+
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,12 @@ gosec_install: ## Install gosec utility
 .PHONY: gosec
 gosec: ## Run go security checks
 	./scripts/run_gosec.sh
+
+.PHONY: lint
+lint: ## Run golangci-lint linter tool
+	golangci-lint run ./... --timeout 15m
+
+.PHONY: lint_install
+lint_install: ## Install golangci-lint linter tool
+	@# TODO(rm3l): recent versions of golangci-lint require Go >= 1.20. Update when we start using Go 1.20+
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3


### PR DESCRIPTION
## What does this PR do?
This PR makes use of the `golangci-lint` [1] linters aggregator, configured with the `depguard`[2] linter to enforce that the deprecated `io/ioutil` [3] package is not used anymore in the code.

NOTE: Ideally, we should use all linters enabled by default by `golangci-lint`. But doing so reports a lot of issues, not relevant to the issue here (which is to enforce that 'io/ioutil' is not used anymore).
Enabling the default linters and fixing the issues reported can be done in a subsequent issue/PR.

[1] https://golangci-lint.run/
[2] https://golangci-lint.run/usage/linters/#depguard
[3] https://pkg.go.dev/io/ioutil#pkg-overview

### Which issue(s) does this PR fix

Fixes https://github.com/devfile/api/issues/1257

### PR acceptance criteria

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer

```sh
# Install golangci-lint
$ make lint_install

# Run linter. It should pass.
$ make lint        
golangci-lint run ./... --timeout 15m

$ echo $?
0
```

Below is an example of error reported should `io/ioutil` be used again:
```
☸ in ~/w/p/d/alizer on  1257-replace-alizer-io-ioutil-dependency--linter-checks (REVERTING) [$+⇡] via 🐹 v1.19.13 
$ make lint        
golangci-lint run ./... --timeout 15m
pkg/apis/enricher/framework/dotnet/dotnet_detector.go:18:2: import 'io/ioutil' is not allowed from list 'main': Deprecated since Go 1.16. Use the implementations from 'io' or 'os' packages instead. (depguard)
        "io/ioutil"
        ^
pkg/apis/recognizer/devfile_recognizer.go:19:2: import 'io/ioutil' is not allowed from list 'main': Deprecated since Go 1.16. Use the implementations from 'io' or 'os' packages instead. (depguard)
        "io/ioutil"
        ^
pkg/utils/detector.go:23:2: import 'io/ioutil' is not allowed from list 'main': Deprecated since Go 1.16. Use the implementations from 'io' or 'os' packages instead. (depguard)
        "io/ioutil"
        ^
test/check_registry/check_registry.go:6:2: import 'io/ioutil' is not allowed from list 'main': Deprecated since Go 1.16. Use the implementations from 'io' or 'os' packages instead. (depguard)
        "io/ioutil"
        ^
make: *** [Makefile:39: lint] Error 1
```
