### PR TITLE
Enable all default golangci-lint linters and fix issues related

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,7 @@ linters:
   # Default: false
   # TODO(rm3l): all default linters are disabled in the context of https://github.com/devfile/api/issues/1257 (to just enforce that io/ioutil is not used anymore),
   #   but we should think about enabling all the default linters and fix the issues reported.
-  disable-all: true
+  disable-all: false
   enable:
     # Go linter that checks if package imports are in a list of acceptable packages
     - depguard

--- a/pkg/apis/enricher/docker_enricher.go
+++ b/pkg/apis/enricher/docker_enricher.go
@@ -32,19 +32,16 @@ func (d DockerEnricher) GetSupportedLanguages() []string {
 
 func (d DockerEnricher) DoEnrichLanguage(language *model.Language, _ *[]string) {
 	// The Dockerfile language does not contain frameworks
-	return
 }
 
 func (d DockerEnricher) DoEnrichComponent(component *model.Component, _ model.DetectionSettings, _ *context.Context) {
 	projectName := GetDefaultProjectName(component.Path)
 	component.Name = projectName
 
-	var ports []int
-	ports = GetPortsFromDockerFile(component.Path)
+	ports := GetPortsFromDockerFile(component.Path)
 	if len(ports) > 0 {
 		component.Ports = ports
 	}
-	return
 }
 
 func (d DockerEnricher) IsConfigValidForComponentDetection(language string, config string) bool {

--- a/pkg/apis/enricher/enricher.go
+++ b/pkg/apis/enricher/enricher.go
@@ -126,11 +126,10 @@ func GetPortsFromDockerFile(root string) []int {
 		cleanFilePath := filepath.Clean(filePath)
 		file, err := os.Open(cleanFilePath)
 		if err == nil {
-			defer func() error {
+			defer func(){
 				if err := file.Close(); err != nil {
-					return fmt.Errorf("error closing file: %s", err)
+					fmt.Printf("error closing file: %s", err)
 				}
-				return nil
 			}()
 			return utils.ReadPortsFromDockerfile(file)
 		}

--- a/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -64,20 +64,23 @@ func getFrameworks(configFilePath string) string {
 	cleanConfigPath := filepath.Clean(configFilePath)
 	xmlFile, err := os.Open(cleanConfigPath)
 	if err != nil {
+		fmt.Printf("error opening file: %s", err)
 		return ""
 	}
-	byteValue, _ := io.ReadAll(xmlFile)
-
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		fmt.Printf("error reading file: %s", err)
+		return ""
+	}
 	var proj schema.DotNetProject
 	err = xml.Unmarshal(byteValue, &proj)
 	if err != nil {
 		return ""
 	}
-	defer func() error {
+	defer func(){
 		if err := xmlFile.Close(); err != nil {
-			return fmt.Errorf("error closing file: %s", err)
+			fmt.Printf("error closing file: %s", err)
 		}
-		return nil
 	}()
 	if proj.PropertyGroup.TargetFramework != "" {
 		return proj.PropertyGroup.TargetFramework

--- a/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
@@ -45,7 +45,8 @@ func (n NuxtDetector) DoFrameworkDetection(language *model.Language, config stri
 
 // DoPortsDetection searches for the port in package.json, and nuxt.config.js
 func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
-	ports := []int{}
+	//ports := []int{}
+	var ports []int
 	regexes := []string{`--port=(\d*)`}
 	// check if port is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)

--- a/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
@@ -45,7 +45,6 @@ func (n NuxtDetector) DoFrameworkDetection(language *model.Language, config stri
 
 // DoPortsDetection searches for the port in package.json, and nuxt.config.js
 func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
-	//ports := []int{}
 	var ports []int
 	regexes := []string{`--port=(\d*)`}
 	// check if port is set in start script in package.json

--- a/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
+++ b/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
@@ -46,7 +46,7 @@ func (v VueDetector) DoFrameworkDetection(language *model.Language, config strin
 // DoPortsDetection searches for the port in package.json, .env file, and vue.config.js
 func (v VueDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	regexes := []string{`--port (\d*)`, `PORT=(\d*)`}
-	ports := []int{}
+	var ports []int
 	// check if --port or PORT is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)
 	if utils.IsValidPort(port) {

--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -242,11 +242,10 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 	if err != nil {
 		return []model.DevfileType{}, err
 	}
-	defer func() error {
+	defer func(){
 		if err := resp.Body.Close(); err != nil {
-			return fmt.Errorf("error closing file: %s", err)
+			fmt.Printf("error closing file: %s", err)
 		}
-		return nil
 	}()
 
 	// Check server response

--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -243,7 +243,7 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 		return []model.DevfileType{}, err
 	}
 
-	defer closeHttpResponseBody(resp)
+	defer utils.CloseHttpResponseBody(resp)
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
@@ -262,12 +262,6 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 	}
 
 	return devfileTypes, nil
-}
-
-func closeHttpResponseBody(resp *http.Response){
-	if err := resp.Body.Close(); err != nil {
-		fmt.Printf("error closing file: %s", err)
-	}
 }
 
 func appendIndexPath(url string) string {

--- a/pkg/apis/recognizer/devfile_recognizer.go
+++ b/pkg/apis/recognizer/devfile_recognizer.go
@@ -242,11 +242,8 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 	if err != nil {
 		return []model.DevfileType{}, err
 	}
-	defer func(){
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("error closing file: %s", err)
-		}
-	}()
+
+	defer closeHttpResponseBody(resp)
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
@@ -265,6 +262,12 @@ var DownloadDevfileTypesFromRegistry = func(url string, filter model.DevfileFilt
 	}
 
 	return devfileTypes, nil
+}
+
+func closeHttpResponseBody(resp *http.Response){
+	if err := resp.Body.Close(); err != nil {
+		fmt.Printf("error closing file: %s", err)
+	}
 }
 
 func appendIndexPath(url string) string {

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"net/http"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/stretchr/testify/assert"
@@ -790,4 +791,32 @@ func getTestProjectPath(folder string) string {
 	_, b, _, _ := runtime.Caller(0)
 	basepath := filepath.Dir(b)
 	return filepath.Join(basepath, "..", "..", "..", "resources/projects", folder)
+}
+
+func TestCloseHttpResponseBody(t *testing.T){
+	tests := []struct {
+		name                string
+		url					string
+	}{
+		{
+			name:   "Closing File",
+			url: "http://www.google.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(tt.url)
+			if err != nil {
+				t.Errorf("Failed to get url")
+			}else {
+				closeHttpResponseBody(resp)
+				_, err = resp.Body.Read(nil)
+				if err == nil{
+					t.Errorf("Failed to close file")
+				}
+			}
+			
+		})
+	}
 }

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -229,7 +229,7 @@ func TestResponseBodyClosing(t *testing.T) {
 			name: "Successful response body closing",
 			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("response body content"))
+				_, _ = w.Write([]byte("response body content"))
 			},
 		},
 	}

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -857,31 +857,3 @@ func getTestProjectPath(folder string) string {
 	basepath := filepath.Dir(b)
 	return filepath.Join(basepath, "..", "..", "..", "resources/projects", folder)
 }
-
-func TestCloseHttpResponseBody(t *testing.T){
-	tests := []struct {
-		name                string
-		url					string
-	}{
-		{
-			name:   "Closing File",
-			url: "http://www.google.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp, err := http.Get(tt.url)
-			if err != nil {
-				t.Errorf("Failed to get url")
-			}else {
-				closeHttpResponseBody(resp)
-				_, err = resp.Body.Read(nil)
-				if err == nil{
-					t.Errorf("Failed to close file")
-				}
-			}
-			
-		})
-	}
-}

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -16,9 +16,6 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"net/http"
-	"net/http/httptest"
-	"io"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/stretchr/testify/assert"
@@ -216,46 +213,6 @@ func TestGetUrlWithVersions(t *testing.T) {
 			} else {
 				assert.EqualValues(t, getExceptedVersionsUrl(tt.testUrl, tt.minSchemaVersion, tt.maxSchemaVersion, tt.expectedError), result)
 			}
-		})
-	}
-}
-
-func TestResponseBodyClosing(t *testing.T) {
-	tests := []struct {
-		name             string
-		mockServerConfig func(w http.ResponseWriter, r *http.Request)
-	}{
-		{
-			name: "Successful response body closing",
-			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("response body content"))
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(tt *testing.T) {
-			// Setup a mock HTTP server
-			server := httptest.NewServer(http.HandlerFunc(tc.mockServerConfig))
-			defer server.Close()
-
-			// Perform a request to the mock server
-			resp, err := http.Get(server.URL)
-			assert.NoError(t, err, "Unexpected error during HTTP GET")
-
-			// Close the response body
-			func() {
-				defer func() {
-					if err := resp.Body.Close(); err != nil {
-						fmt.Printf("error closing file: %s", err)
-					}
-				}()
-
-				body, err := io.ReadAll(resp.Body)
-				assert.NoError(t, err, "Unexpected error reading response body")
-				assert.Equal(t, "response body content", string(body), "Unexpected response body content")
-			}()
 		})
 	}
 }

--- a/pkg/apis/recognizer/devfile_recognizer_test.go
+++ b/pkg/apis/recognizer/devfile_recognizer_test.go
@@ -16,6 +16,9 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"net/http"
+	"net/http/httptest"
+	"io"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/stretchr/testify/assert"
@@ -213,6 +216,46 @@ func TestGetUrlWithVersions(t *testing.T) {
 			} else {
 				assert.EqualValues(t, getExceptedVersionsUrl(tt.testUrl, tt.minSchemaVersion, tt.maxSchemaVersion, tt.expectedError), result)
 			}
+		})
+	}
+}
+
+func TestResponseBodyClosing(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockServerConfig func(w http.ResponseWriter, r *http.Request)
+	}{
+		{
+			name: "Successful response body closing",
+			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("response body content"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			// Setup a mock HTTP server
+			server := httptest.NewServer(http.HandlerFunc(tc.mockServerConfig))
+			defer server.Close()
+
+			// Perform a request to the mock server
+			resp, err := http.Get(server.URL)
+			assert.NoError(t, err, "Unexpected error during HTTP GET")
+
+			// Close the response body
+			func() {
+				defer func() {
+					if err := resp.Body.Close(); err != nil {
+						fmt.Printf("error closing file: %s", err)
+					}
+				}()
+
+				body, err := io.ReadAll(resp.Body)
+				assert.NoError(t, err, "Unexpected error reading response body")
+				assert.Equal(t, "response body content", string(body), "Unexpected response body content")
+			}()
 		})
 	}
 }

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -748,7 +748,9 @@ func NormalizeSplit(file string) (string, string) {
 }
 
 func CloseHttpResponseBody(resp *http.Response){
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		fmt.Printf("error closing file: %s", err)
+	}
 }
 
 func CloseFile(file *os.File){

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"net/http"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/devfile/alizer/pkg/schema"
@@ -751,4 +752,10 @@ func NormalizeSplit(file string) (string, string) {
 		dir = "./"
 	}
 	return dir, fileName
+}
+
+func CloseHttpResponseBody(resp *http.Response){
+	if err := resp.Body.Close(); err != nil {
+		fmt.Printf("error closing file: %s", err)
+	}
 }

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -145,11 +145,8 @@ func GetPomFileContent(pomFilePath string) (schema.Pom, error) {
 	if err != nil {
 		return schema.Pom{}, err
 	}
-	defer func(){
-		if err := xmlFile.Close(); err != nil {
-			fmt.Printf("error closing file: %s", err)
-		}
-	}()
+
+	defer CloseFile(xmlFile)
 	return pom, nil
 }
 
@@ -356,11 +353,7 @@ func GetEnvVarsFromDockerFile(root string) ([]model.EnvVar, error) {
 		cleanFilePath := filepath.Clean(filePath)
 		file, err := os.Open(cleanFilePath)
 		if err == nil {
-			defer func(){
-				if err := file.Close(); err != nil {
-					fmt.Printf("error closing file: %s", err)
-				}
-			}()
+			defer CloseFile(file)
 			return readEnvVarsFromDockerfile(file)
 		}
 	}
@@ -755,7 +748,11 @@ func NormalizeSplit(file string) (string, string) {
 }
 
 func CloseHttpResponseBody(resp *http.Response){
-	if err := resp.Body.Close(); err != nil {
+	resp.Body.Close()
+}
+
+func CloseFile(file *os.File){
+	if err := file.Close(); err != nil {
 		fmt.Printf("error closing file: %s", err)
 	}
 }

--- a/pkg/utils/detector.go
+++ b/pkg/utils/detector.go
@@ -134,18 +134,20 @@ func GetPomFileContent(pomFilePath string) (schema.Pom, error) {
 	if err != nil {
 		return schema.Pom{}, err
 	}
-	byteValue, _ := io.ReadAll(xmlFile)
-
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		return schema.Pom{}, err
+	}
+	
 	var pom schema.Pom
 	err = xml.Unmarshal(byteValue, &pom)
 	if err != nil {
 		return schema.Pom{}, err
 	}
-	defer func() error {
+	defer func(){
 		if err := xmlFile.Close(); err != nil {
-			return fmt.Errorf("error closing file: %s", err)
+			fmt.Printf("error closing file: %s", err)
 		}
-		return nil
 	}()
 	return pom, nil
 }
@@ -353,11 +355,10 @@ func GetEnvVarsFromDockerFile(root string) ([]model.EnvVar, error) {
 		cleanFilePath := filepath.Clean(filePath)
 		file, err := os.Open(cleanFilePath)
 		if err == nil {
-			defer func() error {
+			defer func(){
 				if err := file.Close(); err != nil {
-					return fmt.Errorf("error closing file: %s", err)
+					fmt.Printf("error closing file: %s", err)
 				}
-				return nil
 			}()
 			return readEnvVarsFromDockerfile(file)
 		}

--- a/pkg/utils/detector_test.go
+++ b/pkg/utils/detector_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
+	"net/http"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/devfile/alizer/pkg/schema"
@@ -1952,6 +1953,34 @@ func TestGetApplicationFileInfo(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetApplicationFileInfo() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestCloseHttpResponseBody(t *testing.T){
+	tests := []struct {
+		name                string
+		url					string
+	}{
+		{
+			name:   "Closing File",
+			url: "http://www.google.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(tt.url)
+			if err != nil {
+				t.Errorf("Failed to get url")
+			}else {
+				CloseHttpResponseBody(resp)
+				_, err = resp.Body.Read(nil)
+				if err == nil{
+					t.Errorf("Failed to close file")
+				}
+			}
+			
 		})
 	}
 }

--- a/pkg/utils/detector_test.go
+++ b/pkg/utils/detector_test.go
@@ -591,7 +591,8 @@ func TestIsTagInPomXMLFile(t *testing.T) {
 
 func TestGetPomFileContent(t *testing.T) {
 	missingFileErr := "no such file or directory"
-
+	badXmlFileErr := "XML syntax error on line 1: expected attribute name in element"
+	
 	testCases := []struct {
 		name           string
 		filePath       string
@@ -637,6 +638,12 @@ func TestGetPomFileContent(t *testing.T) {
 			filePath:       "path/to/nonexistent/file.xml",
 			expectedResult: schema.Pom{},
 			expectedError:  &missingFileErr,
+		},
+		{
+			name:           "Case 3: File is unreadable",
+			filePath:       "testdata/bad-xml.xml",
+			expectedResult: schema.Pom{},
+			expectedError:  &badXmlFileErr,
 		},
 	}
 

--- a/pkg/utils/detector_test.go
+++ b/pkg/utils/detector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"net/http"
 	"net/http/httptest"
+	"io"
 
 	"github.com/devfile/alizer/pkg/apis/model"
 	"github.com/devfile/alizer/pkg/schema"
@@ -642,7 +643,7 @@ func TestGetPomFileContent(t *testing.T) {
 			expectedError:  &missingFileErr,
 		},
 		{
-			name:           "Case 3: File is unreadable",
+			name:           "Case 3: File is unreadable (cannot unmarshal)",
 			filePath:       "testdata/bad-xml.xml",
 			expectedResult: schema.Pom{},
 			expectedError:  &badXmlFileErr,
@@ -1970,10 +1971,13 @@ func TestCloseHttpResponseBody(t *testing.T){
 	tests := []struct {
 		name                string
 		url					string
+		expectErr			bool
+		expectedOut			string
 	}{
 		{
-			name:   "Closing File",
+			name:   "Case 1: Successful Closing of File",
 			url: server.URL,
+			expectedOut: "",
 		},
 	}
 
@@ -1981,10 +1985,57 @@ func TestCloseHttpResponseBody(t *testing.T){
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := http.Get(tt.url)
 			assert.Empty(t, err)
-			CloseHttpResponseBody(resp)
-			_, err = resp.Body.Read(nil)
-			assert.Error(t, err)
 
+			// Below section handles the capturing of the fmt.Printf in the func being tested
+			captureStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			CloseHttpResponseBody(resp)
+			w.Close()
+			out, _ := io.ReadAll(r)
+			os.Stdout = captureStdout
+			assert.EqualValues(t, tt.expectedOut, out)
+
+		})
+	}
+}
+
+func TestCloseFile(t *testing.T){
+	tests := []struct {
+		name                string
+		expectErr			bool
+		expectedOut			string
+	}{
+		{
+			name:   "Case 1: Filed closed",
+			expectErr: false,
+			expectedOut: "",
+		},
+		{
+			name: "Case 2: File not closed",
+			expectErr: true,
+			expectedOut: "error closing file: close testdata/pom-dependency.xml: file already closed",
+		},
+	}
+
+	file_path := "testdata/pom-dependency.xml"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			open_file, _ := os.Open(file_path)
+			// Below section handles the capturing of the fmt.Printf in the func being tested
+			captureStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			// Mocking the hit of a close failure by preclosing the file
+			if tt.expectErr {
+				open_file.Close()
+			}
+			CloseFile(open_file)
+			w.Close()
+			out, _ := io.ReadAll(r)
+			os.Stdout = captureStdout
+			assert.EqualValues(t, tt.expectedOut, string(out))
 		})
 	}
 }

--- a/pkg/utils/langfiles/languages_file_handler.go
+++ b/pkg/utils/langfiles/languages_file_handler.go
@@ -184,9 +184,7 @@ func (l *LanguageFile) GetConfigurationPerLanguageMapping() map[string][]string 
 func (l *LanguageFile) GetExcludedFolders() []string {
 	var excludedFolders []string
 	for _, langItem := range l.languages {
-		for _, exclude := range langItem.ExcludeFolders {
-			excludedFolders = append(excludedFolders, exclude)
-		}
+		excludedFolders = append(excludedFolders, langItem.ExcludeFolders...)
 	}
 	excludedFolders = removeDuplicates(excludedFolders)
 	return excludedFolders

--- a/pkg/utils/logger_test.go
+++ b/pkg/utils/logger_test.go
@@ -83,7 +83,10 @@ func TestGetOrCreateLogger(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.activate {
-				GenLogger("info")
+				err := GenLogger("info")
+				if err != nil {
+					t.Errorf("%s", err)
+				}
 			}
 			logger := GetOrCreateLogger()
 			assert.EqualValues(t, true, logger.GetSink().Enabled(int(tt.expectedLevel)))

--- a/pkg/utils/testdata/bad-xml.xml
+++ b/pkg/utils/testdata/bad-xml.xml
@@ -1,0 +1,12 @@
+<xl version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>dependency</artifactId>
+        </dependency>
+    </dependencies>
+<project>

--- a/test/apis/utils.go
+++ b/test/apis/utils.go
@@ -19,11 +19,10 @@ func updateContent(filePath string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer func() error {
+	defer func(){
 		if err := f.Close(); err != nil {
-			return fmt.Errorf("error closing file: %s", err)
+			fmt.Printf("error closing file: %s", err)
 		}
-		return nil
 	}()
 	if _, err := f.Write(data); err != nil {
 		return err

--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devfile/alizer/pkg/apis/model"
 	recognizer "github.com/devfile/alizer/pkg/apis/recognizer"
 	"github.com/devfile/alizer/pkg/schema"
+	"github.com/devfile/alizer/pkg/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -105,7 +106,7 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 	if err != nil {
 		return []StarterProject{}, err
 	}
-	defer closeHttpResponseBody(resp)
+	defer utils.CloseHttpResponseBody(resp)
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
@@ -134,12 +135,6 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 		})
 	}
 	return starterProjects, nil
-}
-
-func closeHttpResponseBody(resp *http.Response){
-	if err := resp.Body.Close(); err != nil {
-		fmt.Printf("error closing file: %s", err)
-	}
 }
 
 func appendIfMissing(slice []RegistryCheckJSONItem, r RegistryCheckJSONItem) []RegistryCheckJSONItem {

--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -105,11 +105,7 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 	if err != nil {
 		return []StarterProject{}, err
 	}
-	defer func(){
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("error closing file: %s", err)
-		}
-	}()
+	defer closeHttpResponseBody(resp)
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
@@ -138,6 +134,12 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 		})
 	}
 	return starterProjects, nil
+}
+
+func closeHttpResponseBody(resp *http.Response){
+	if err := resp.Body.Close(); err != nil {
+		fmt.Printf("error closing file: %s", err)
+	}
 }
 
 func appendIfMissing(slice []RegistryCheckJSONItem, r RegistryCheckJSONItem) []RegistryCheckJSONItem {

--- a/test/check_registry/check_registry.go
+++ b/test/check_registry/check_registry.go
@@ -105,11 +105,10 @@ func getStarterProjects(url string) ([]StarterProject, error) {
 	if err != nil {
 		return []StarterProject{}, err
 	}
-	defer func() error {
+	defer func(){
 		if err := resp.Body.Close(); err != nil {
-			return fmt.Errorf("error closing file: %s", err)
+			fmt.Printf("error closing file: %s", err)
 		}
-		return nil
 	}()
 
 	// Check server response

--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -90,7 +90,7 @@ func TestResponseBodyClosingStarterProjects(t *testing.T) {
 			name: "Successful response body closing",
 			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("response body content"))
+				_, _ = w.Write([]byte("response body content"))
 			},
 		},
 	}

--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/url"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,34 +73,6 @@ func TestGetStarterProjects(t *testing.T) {
 			for _, starterProject := range starterProjects {
 				assert.EqualValues(t, starterProject.Repo, tt.expectedUrl)
 			}
-		})
-	}
-}
-
-func TestCloseHttpResponseBody(t *testing.T){
-	tests := []struct {
-		name                string
-		url					string
-	}{
-		{
-			name:   "Closing File",
-			url: "http://www.google.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp, err := http.Get(tt.url)
-			if err != nil {
-				t.Errorf("Failed to get url")
-			}else {
-				closeHttpResponseBody(resp)
-				_, err = resp.Body.Read(nil)
-				if err == nil{
-					t.Errorf("Failed to close file")
-				}
-			}
-			
 		})
 	}
 }

--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,6 +74,34 @@ func TestGetStarterProjects(t *testing.T) {
 			for _, starterProject := range starterProjects {
 				assert.EqualValues(t, starterProject.Repo, tt.expectedUrl)
 			}
+		})
+	}
+}
+
+func TestCloseHttpResponseBody(t *testing.T){
+	tests := []struct {
+		name                string
+		url					string
+	}{
+		{
+			name:   "Closing File",
+			url: "http://www.google.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Get(tt.url)
+			if err != nil {
+				t.Errorf("Failed to get url")
+			}else {
+				closeHttpResponseBody(resp)
+				_, err = resp.Body.Read(nil)
+				if err == nil{
+					t.Errorf("Failed to close file")
+				}
+			}
+			
 		})
 	}
 }

--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -3,10 +3,6 @@ package main
 import (
 	"net/url"
 	"testing"
-	"net/http"
-	"net/http/httptest"
-	"io"
-	"fmt"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -77,46 +73,6 @@ func TestGetStarterProjects(t *testing.T) {
 			for _, starterProject := range starterProjects {
 				assert.EqualValues(t, starterProject.Repo, tt.expectedUrl)
 			}
-		})
-	}
-}
-
-func TestResponseBodyClosingStarterProjects(t *testing.T) {
-	tests := []struct {
-		name             string
-		mockServerConfig func(w http.ResponseWriter, r *http.Request)
-	}{
-		{
-			name: "Successful response body closing",
-			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("response body content"))
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(tt *testing.T) {
-			// Setup a mock HTTP server
-			server := httptest.NewServer(http.HandlerFunc(tc.mockServerConfig))
-			defer server.Close()
-
-			// Perform a request to the mock server
-			resp, err := http.Get(server.URL)
-			assert.NoError(t, err, "Unexpected error during HTTP GET")
-
-			// Close the response body
-			func() {
-				defer func() {
-					if err := resp.Body.Close(); err != nil {
-						fmt.Printf("error closing file: %s", err)
-					}
-				}()
-
-				body, err := io.ReadAll(resp.Body)
-				assert.NoError(t, err, "Unexpected error reading response body")
-				assert.Equal(t, "response body content", string(body), "Unexpected response body content")
-			}()
 		})
 	}
 }

--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"net/url"
 	"testing"
+	"net/http"
+	"net/http/httptest"
+	"io"
+	"fmt"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -73,6 +77,46 @@ func TestGetStarterProjects(t *testing.T) {
 			for _, starterProject := range starterProjects {
 				assert.EqualValues(t, starterProject.Repo, tt.expectedUrl)
 			}
+		})
+	}
+}
+
+func TestResponseBodyClosingStarterProjects(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockServerConfig func(w http.ResponseWriter, r *http.Request)
+	}{
+		{
+			name: "Successful response body closing",
+			mockServerConfig: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("response body content"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			// Setup a mock HTTP server
+			server := httptest.NewServer(http.HandlerFunc(tc.mockServerConfig))
+			defer server.Close()
+
+			// Perform a request to the mock server
+			resp, err := http.Get(server.URL)
+			assert.NoError(t, err, "Unexpected error during HTTP GET")
+
+			// Close the response body
+			func() {
+				defer func() {
+					if err := resp.Body.Close(); err != nil {
+						fmt.Printf("error closing file: %s", err)
+					}
+				}()
+
+				body, err := io.ReadAll(resp.Body)
+				assert.NoError(t, err, "Unexpected error reading response body")
+				assert.Equal(t, "response body content", string(body), "Unexpected response body content")
+			}()
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?
This PR enables the default linters that were disabled in a prior issue and fixes all of the issues presented by the default linters.
<!-- _Summarize the changes_ -->

### Which issue(s) does this PR fix
resolves https://github.com/devfile/api/issues/1302
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria

- [ ] Enable default linters
- [ ] All issues reported by `make lint` are dealt with and `make lint` passes
- [ ] All tests pass in `make test`

### How to test changes / Special notes to the reviewer
You can test these changes by first running `make lint` to verify there are no more lint errors being reported. You can also run `make test` to ensure all unit tests also pass with the changes.