### PR TITLE
[Devtools Week] Create linux arm64 binary after every release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
           - 'linux/amd64'
           - 'linux/ppc64le'
           - 'linux/s390x'
+          - 'linux/arm64'
           - 'windows/amd64'
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,11 @@ jobs:
       matrix:
         goosarch:
           - 'darwin/amd64'
+          - 'darwin/arm64'
           - 'linux/amd64'
+          - 'linux/arm64'
           - 'linux/ppc64le'
           - 'linux/s390x'
-          - 'linux/arm64'
           - 'windows/amd64'
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What does this PR do?

This PR adds support for an `linux/arm64` binary on every release we make for alizer.

### Which issue(s) does this PR fix

Part of the devtools week

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests
- [x] Documentation

### How to test changes / Special notes to the reviewer

An example release is here: https://github.com/thepetk/devfile-alizer/releases/tag/v1.3.1