### PR TITLE
Add slack notification step for nightly run failures 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: '1.19'
 
@@ -56,14 +56,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
       - name: Set up Go 1.x
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.19
       - name: Run tests
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-  - cron: "0 3 * * *"
+    - cron: "0 3 * * *"
 
 name: Product & Community Registries Check
 
@@ -14,7 +14,7 @@ permissions:
 jobs:
   check-registry:
     name: Check registry entries
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     outputs:
       matrix: ${{ steps.get-stacks.outputs.matrix }}
     steps:
@@ -27,9 +27,43 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19.5'
+          go-version: "1.19.5"
       - name: Run registries check
         id: build
         run: |
           make build
           make check_registry
+      - name: Send slack notification
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Product & Community Registries Nightly Run"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github: Failed action"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - name: Checkout code
         id: checkout-code
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0
       - name: Setup go
         id: setup-go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "1.19.5"
       - name: Run registries check
@@ -35,7 +35,7 @@ jobs:
           make check_registry
       - name: Send slack notification
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           payload: |

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for ${{ github.ref }} - ${{ github.sha }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for `${{ github.ref }}` - `${{ github.sha }}`"
                   }
                 },
                 {

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.ref }}"
                   }
                 },
                 {

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -65,5 +65,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Product & Community Registries Nightly Run"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
                   }
                 },
                 {

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.ref }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for ${{ github.ref }} - ${{ github.sha }}"
                   }
                 },
                 {

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -34,7 +34,7 @@ jobs:
           make build
           make check_registry
       - name: Send slack notification
-        if: ${{ failure() }}
+        if: ${{ failure() &&  github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.github/workflows/check_registry.yaml
+++ b/.github/workflows/check_registry.yaml
@@ -46,7 +46,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
+                    "text": "*Status:* :red_circle: failure\n*Severity:* medium\n*Title:* Alizer's product & community registries nightly run\n*Description:* run failed for HEAD_REF ${{ github.head_ref }}"
                   }
                 },
                 {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,6 @@ jobs:
           - 'linux/arm64'
           - 'linux/ppc64le'
           - 'linux/s390x'
-          - 'linux/arm64'
           - 'windows/amd64'
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
           - 'linux/arm64'
           - 'linux/ppc64le'
           - 'linux/s390x'
+          - 'linux/arm64'
           - 'windows/amd64'
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,10 @@ jobs:
           - 'windows/amd64'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: '1.19.5'
       - name: Get OS and arch info
@@ -53,7 +53,7 @@ jobs:
         run: |
           go build -o "$BINARY_NAME" -v
       - name: Release with Notes and Binaries
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: false
           files: ${{env.BINARY_NAME}}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v7
+    - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "This issue is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 60 days."


### PR DESCRIPTION
## What does this PR do?

This PR adds an extra step in the `check_registry.yaml` workflow. In case of failure, it sends a message in a specific slack channel using a secret `SLACK_WEBHOOK_URL`.

The format of the message has been defined inside the related issue.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1255

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer