### PR TITLE
Add security-insights distribution-points

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -20,6 +20,8 @@ security-testing:
   tool-name: Dependabot
   comment: |
     Dependabot is enabled for this repo.
+distribution-points:
+  - https://github.com/devfile/alizer
 contribution-policy:
   accepts-pull-requests: true
   accepts-automated-pull-requests: true


### PR DESCRIPTION
## What does this PR do?

As suggested inside the `alizer_security` clo monitoring, a `distribution-points` section should be added inside the `SECURITY-INSIGHTS.yml`. Following examples for other repos the distribution points value can be the link to alizer's repo.

### Which issue(s) does this PR fix

related to https://github.com/devfile/api/issues/1374

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
