### PR TITLE
Fix springboot devfile sample expected URL

### DIFF
--- a/test/check_registry/check_registry_test.go
+++ b/test/check_registry/check_registry_test.go
@@ -60,7 +60,7 @@ func TestGetStarterProjects(t *testing.T) {
 		{
 			name:        "Case 1: Validated registries urls",
 			devfileUrl:  "https://registry.devfile.io/devfiles/java-maven",
-			expectedUrl: "https://github.com/odo-devfiles/springboot-ex.git",
+			expectedUrl: "https://github.com/devfile-samples/springboot-ex.git",
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

After the completion of https://github.com/devfile/api/issues/1604 the springboot sample has been moved to the `devfile-samples` org from the `odo-devfiles`. Currently the alizer checks are failing as we're still expecting the old url.

### Which issue(s) does this PR fix

N/A

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
Tests are now passing