### PR TITLE
Alizer updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           sarif_file: gosec.sarif
 
   code-coverage-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           sarif_file: gosec.sarif
 
   code-coverage-report:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alizer
 
-![Go](https://img.shields.io/badge/Go-1.23-blue)
+![Go](https://img.shields.io/badge/Go-1.24-blue)
 [![Build status](https://github.com/devfile/alizer/actions/workflows/CI.yml/badge.svg)](https://github.com/devfile/alizer/actions/workflows/CI.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](./LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8254/badge)](https://www.bestpractices.dev/projects/8254)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/alizer
 
-go 1.23
+go 1.24
 
 require (
 	github.com/go-git/go-git/v5 v5.13.2

--- a/test/check_registry/check_registry.sh
+++ b/test/check_registry/check_registry.sh
@@ -84,12 +84,17 @@ do
 
     # If the correct devfile is not matched throw error
     if [ "$found_matching" == "0" ]; then
-        let ENTRIES_FAILED++
-        echo "[FAIL] Failed to match project $repo with expected $devfile. Command ./alizer devfile --registry $registry $path"
-        echo "[FAIL] Output: $alizer_output"
-        echo "(PASSED: $ENTRIES_PASSED / FAILED: $ENTRIES_FAILED)"
-        rm -rf tmp/$devfile
-        exit 1
+        # nodejs-mongodb similar to nodejs
+        if [[ "$repo" == "https://github.com/che-samples/nodejs-mongodb-sample" && "$devfile" == "nodejs-mongodb" ]]; then
+            echo "[WARNING] $repo matched with $devfile. Will not raise error."
+        else
+            let ENTRIES_FAILED++
+            echo "[FAIL] Failed to match project $repo with expected $devfile. Command ./alizer devfile --registry $registry $path"
+            echo "[FAIL] Output: $alizer_output"
+            echo "(PASSED: $ENTRIES_PASSED / FAILED: $ENTRIES_FAILED)"
+            rm -rf tmp/$devfile
+            exit 1
+        fi
     fi
     rm -rf tmp/$devfile
 done

--- a/test/check_registry/check_registry.sh
+++ b/test/check_registry/check_registry.sh
@@ -85,8 +85,8 @@ do
     # If the correct devfile is not matched throw error
     if [ "$found_matching" == "0" ]; then
         # nodejs-mongodb similar to nodejs
-        if [[ "$repo" == "https://github.com/che-samples/nodejs-mongodb-sample" && "$devfile" == "nodejs-mongodb" ]]; then
-            echo "[WARNING] $repo matched with $devfile. Will not raise error."
+        if [[ "$repo" == "https://github.com/che-samples/nodejs-mongodb-sample" && "$selected_devfile_name" == "nodejs" ]]; then
+            echo "[WARNING] $repo matched with $selected_devfile_name instead of $devfile. Will not raise error."
         else
             let ENTRIES_FAILED++
             echo "[FAIL] Failed to match project $repo with expected $devfile. Command ./alizer devfile --registry $registry $path"


### PR DESCRIPTION
# Description of Changes

The PR combines two issues:

* First it adds a check in the `check_registry.sh` script to skip the `nodejs-mongodb` stack if its starter project is matched with `nodejs`
* It also upgrades golang version to 1.24

# Related Issue(s)

Fixes https://github.com/devfile/api/issues/1709
Fixes https://github.com/devfile/api/issues/1713

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
_Testing and documentation do not need to be complete in order for this PR to be approved. However, tracking issues must be opened for missing testing/documentation._

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._


# How To Test

First build alizer -> `make build`

You can run from the project's root `bash test/check_registry/check_registry.sh`