### PR TITLE
separate spring boot and spring cloud from spring detection

### DIFF
--- a/pkg/apis/enricher/framework/java/spring_boot_detector.go
+++ b/pkg/apis/enricher/framework/java/spring_boot_detector.go
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+
+package enricher
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/devfile/alizer/pkg/apis/model"
+	"github.com/devfile/alizer/pkg/utils"
+)
+
+type SpringBootDetector struct{}
+
+func (s SpringBootDetector) GetSupportedFrameworks() []string {
+	return []string{"Spring Boot"}
+}
+
+func (s SpringBootDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.properties",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yml",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yaml",
+		},
+	}
+}
+
+// DoFrameworkDetection uses the groupId to check for the framework name
+func (s SpringBootDetector) DoFrameworkDetection(language *model.Language, config string) {
+	if hasFwk, _ := hasFramework(config, "org.springframework.boot", ""); hasFwk {
+		language.Frameworks = append(language.Frameworks, s.GetSupportedFrameworks()...)
+	}
+}
+
+// DoPortsDetection searches for ports in the env var and
+// src/main/resources/application.properties, or src/main/resources/application.yaml
+func (s SpringBootDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	// case: port is set on env var
+	ports := getSpringPortsFromEnvs()
+	if len(ports) > 0 {
+		component.Ports = ports
+		return
+	}
+
+	// check if port is set on env var of dockerfile
+	ports = getSpringPortsFromEnvDockerfile(component.Path)
+	if len(ports) > 0 {
+		component.Ports = ports
+		return
+	}
+
+	// check if port is set inside application file
+	appFileInfos := s.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	applicationFile := utils.GetAnyApplicationFilePath(component.Path, appFileInfos, ctx)
+	if applicationFile == "" {
+		return
+	}
+
+	var err error
+	if filepath.Ext(applicationFile) == ".yml" || filepath.Ext(applicationFile) == ".yaml" {
+		ports, err = getServerPortsFromYamlFile(applicationFile)
+	} else {
+		ports, err = getServerPortsFromPropertiesFile(applicationFile)
+	}
+	if err != nil {
+		return
+	}
+	component.Ports = ports
+}

--- a/pkg/apis/enricher/framework/java/spring_cloud_detector.go
+++ b/pkg/apis/enricher/framework/java/spring_cloud_detector.go
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+
+package enricher
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/devfile/alizer/pkg/apis/model"
+	"github.com/devfile/alizer/pkg/utils"
+)
+
+type SpringCloudDetector struct{}
+
+func (s SpringCloudDetector) GetSupportedFrameworks() []string {
+	return []string{"Spring Cloud"}
+}
+
+func (s SpringCloudDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {
+	return []model.ApplicationFileInfo{
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.properties",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yml",
+		},
+		{
+			Context: ctx,
+			Root:    componentPath,
+			Dir:     "src/main/resources",
+			File:    "application.yaml",
+		},
+	}
+}
+
+// DoFrameworkDetection uses the groupId to check for the framework name
+func (s SpringCloudDetector) DoFrameworkDetection(language *model.Language, config string) {
+	if hasFwk, _ := hasFramework(config, "org.springframework.cloud", ""); hasFwk {
+		language.Frameworks = append(language.Frameworks, s.GetSupportedFrameworks()...)
+	}
+}
+
+// DoPortsDetection searches for ports in the env var and
+// src/main/resources/application.properties, or src/main/resources/application.yaml
+func (s SpringCloudDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	// case: port is set on env var
+	ports := getSpringPortsFromEnvs()
+	if len(ports) > 0 {
+		component.Ports = ports
+		return
+	}
+
+	// check if port is set on env var of dockerfile
+	ports = getSpringPortsFromEnvDockerfile(component.Path)
+	if len(ports) > 0 {
+		component.Ports = ports
+		return
+	}
+
+	// check if port is set inside application file
+	appFileInfos := s.GetApplicationFileInfos(component.Path, ctx)
+	if len(appFileInfos) == 0 {
+		return
+	}
+
+	applicationFile := utils.GetAnyApplicationFilePath(component.Path, appFileInfos, ctx)
+	if applicationFile == "" {
+		return
+	}
+
+	var err error
+	if filepath.Ext(applicationFile) == ".yml" || filepath.Ext(applicationFile) == ".yaml" {
+		ports, err = getServerPortsFromYamlFile(applicationFile)
+	} else {
+		ports, err = getServerPortsFromPropertiesFile(applicationFile)
+	}
+	if err != nil {
+		return
+	}
+	component.Ports = ports
+}

--- a/pkg/apis/enricher/framework/java/spring_detector.go
+++ b/pkg/apis/enricher/framework/java/spring_detector.go
@@ -25,7 +25,7 @@ import (
 type SpringDetector struct{}
 
 func (s SpringDetector) GetSupportedFrameworks() []string {
-	return []string{"Spring", "Spring Boot"}
+	return []string{"Spring"}
 }
 
 func (s SpringDetector) GetApplicationFileInfos(componentPath string, ctx *context.Context) []model.ApplicationFileInfo {

--- a/pkg/apis/enricher/java_enricher.go
+++ b/pkg/apis/enricher/java_enricher.go
@@ -31,6 +31,8 @@ func getJavaFrameworkDetectors() []FrameworkDetectorWithConfigFile {
 		&framework.OpenLibertyDetector{},
 		&framework.QuarkusDetector{},
 		&framework.SpringDetector{},
+		&framework.SpringBootDetector{},
+		&framework.SpringCloudDetector{},
 		&framework.VertxDetector{},
 		&framework.WildFlyDetector{},
 		&framework.JBossEAPDetector{},


### PR DESCRIPTION
# Description of Changes

For a pure `Spring` (non-`Spring Boot`) project, currently it detects as `Spring, Spring Boot` because of hardcoded frameworks.
This PR is to separate the `Spring Boot`, `Spring Cloud` from `Spring` detection.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
_Testing and documentation do not need to be complete in order for this PR to be approved. However, tracking issues must be opened for missing testing/documentation._

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

# Tests Performed

- [X] For a pure Spring project, it detects as `Spring` only, no `Spring Boot`.
- [X] For a Spring Boot project, it detects as `Spring`, `Spring Boot`.

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
