### PR TITLE
Exclude resources from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@
 
 version: 2
 updates:
-- package-ecosystem: "gomod" # See documentation for possible values
-  directory: "/" # Location of package manifests
+- package-ecosystem: "gomod"
+  directory: "/"
   schedule:
     interval: "weekly"
   reviewers:
   - "devfile/devfile-services-team"
+  exclude-paths:
+  - "resources/**"


### PR DESCRIPTION
# Description of Changes

Reduces the noise from `dependabot` checks into the `resources/` dir (the dir is only used for testing.

Based on: https://github.blog/changelog/2025-08-26-dependabot-can-now-exclude-automatic-pull-requests-for-manifests-in-selected-subdirectories/

# Related Issue(s)
N/A

# Acceptance Criteria

- The PR should skip any PRs/Checks for projects under resources/ dir

_Testing and documentation do not need to be complete in order for this PR to be approved. However, tracking issues must be opened for missing testing/documentation._

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._


# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
