### PR TITLE
fix(check_registry): correct org name of nodejs-mongodb-sample starter project

### DIFF
--- a/test/check_registry/check_registry.sh
+++ b/test/check_registry/check_registry.sh
@@ -34,6 +34,11 @@ REGISTRY_ENTRIES_OUTPUT=$(go run test/check_registry/check_registry.go)
 ENTRIES_PASSED=0
 ENTRIES_FAILED=0
 
+# Declare a map of similar devfile starter projects to ignore errors for
+declare -A IGNORED_SIMILAR_DEVFILES=(
+    ["https://github.com/devfile-samples/nodejs-mongodb-sample"]="nodejs"
+)
+
 for entry in $(echo $REGISTRY_ENTRIES_OUTPUT | jq -c '.[]')
 do
     # Assign variables for this entry
@@ -84,8 +89,8 @@ do
 
     # If the correct devfile is not matched throw error
     if [ "$found_matching" == "0" ]; then
-        # nodejs-mongodb similar to nodejs
-        if [[ "$repo" == "https://github.com/che-samples/nodejs-mongodb-sample" && "$selected_devfile_name" == "nodejs" ]]; then
+        # ignore error on similar devfiles
+        if [[ "${IGNORED_SIMILAR_DEVFILES[$repo]}" == "$selected_devfile_name" ]]; then
             echo "[WARNING] $repo matched with $selected_devfile_name instead of $devfile. Will not raise error."
         else
             let ENTRIES_FAILED++


### PR DESCRIPTION
# Description of Changes

With the migration of https://github.com/che-samples/nodejs-mongodb-sample into https://github.com/devfile-samples/nodejs-mongodb-sample (see https://github.com/eclipse-che/che/issues/23850), the hard-coded ignore condition for this test suite needed fixing.

I've both changed the org name to use devfile-samples and refactored the check to use a key-based associative array to store all starter projects and similar devfile names to ignore errors.

# Related Issue(s)

fixes https://github.com/devfile/api/issues/1776

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
_Testing and documentation do not need to be complete in order for this PR to be approved. However, tracking issues must be opened for missing testing/documentation._

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._


# How To Test
_Instructions for the reviewer on how to test your changes._

`make registry_check`

# Notes To Reviewer
_Any notes you would like to include for the reviewer._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced registry validation with improved error handling for known deviations and centralized configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->